### PR TITLE
[FEATURE] Seperate radioVolume variable with exported getter and setter

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -2,6 +2,7 @@ local Cfg = Cfg
 local currentGrid = 0
 -- we can't use GetConvarInt because its not a integer, and theres no way to get a float... so use a hacky way it is!
 local volume = tonumber(GetConvar('voice_defaultVolume', '0.3'))
+local radioVolume = volume
 local micClicks = true
 playerServerId = GetPlayerServerId(PlayerId())
 radioEnabled, radioPressed, mode, radioChannel, callChannel = false, false, 2, 0, 0
@@ -58,12 +59,25 @@ AddAudioSubmixOutput(phoneEffectId, 1)
 
 local submixFunctions = {
 	['radio'] = function(plySource)
+		MumbleSetVolumeOverrideByServerId(plySource, radioVolume)
 		MumbleSetSubmixForServerId(plySource, radioEffectId)
 	end,
 	['phone'] = function(plySource)
 		MumbleSetSubmixForServerId(plySource, phoneEffectId)
 	end
 }
+
+-- function getRadioVolume (can be used as export)
+-- returns radioVolume as float
+function getRadioVolume()
+    return radioVolume
+end
+
+-- function setRadioVolume (can be used as export)
+-- sets radioVolume as float
+function setRadioVolume(value)
+    radioVolume = value
+end
 
 --- function toggleVoice
 --- Toggles the players voice

--- a/client/main.lua
+++ b/client/main.lua
@@ -59,7 +59,7 @@ AddAudioSubmixOutput(phoneEffectId, 1)
 
 local submixFunctions = {
 	['radio'] = function(plySource)
-		MumbleSetVolumeOverrideByServerId(plySource, radioVolume)
+		MumbleSetVolumeOverrideByServerId(plySource, radioVolume or volume)
 		MumbleSetSubmixForServerId(plySource, radioEffectId)
 	end,
 	['phone'] = function(plySource)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -32,3 +32,6 @@ provides {
     'toko-voip',
     'tokovoip_script'
 }
+
+export 'getRadioVolume'
+export 'setRadioVolume'


### PR DESCRIPTION
This adds two exported functions, which makes an external resource able to set and get the current radioVolume

**Example for usage:**
```
local currentRadioVolume = exports["pma-voice"]:getRadioVolume()
local newRadioVolume = newexports["pma-voice"]:setRadioVolume(newRadioVolume)
```