### PR TITLE
fix(client/plyState): plyState variable not global

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -5,7 +5,7 @@ local volumes = {
 	['radio'] = tonumber(GetConvar('voice_defaultVolume', '0.3')),
 	['phone'] = tonumber(GetConvar('voice_defaultVolume', '0.3')),
 }
-local plyState = LocalPlayer.state
+plyState = LocalPlayer.state
 local micClicks = true
 playerServerId = GetPlayerServerId(PlayerId())
 radioEnabled, radioPressed, mode, radioChannel, callChannel = false, false, 2, 0, 0


### PR DESCRIPTION
Error: Attempt to index a nil value (global 'plyState')
Reason: plyState was local only on main.lua
Fix: change plyState from local to global so it can be accessed from radio.lua and phone.lua