### PR TITLE
fix(volume): Fixes setCallVolume export setting wrong volume

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,7 +55,7 @@ exports("setRadioVolume", function(vol)
 	setVolume(vol, 'radio')
 end)
 exports("setCallVolume", function(vol)
-	setVolume(vol, 'call')
+	setVolume(vol, 'phone')
 end)
 
 -- default submix incase people want to fiddle with it.


### PR DESCRIPTION
Calling setCallVolume export, throws error. This commit fixes it.