### PR TITLE
Force zone if currentRoutingBucket ~= 0 (fix "instance" voice) [TESTED]

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -300,6 +300,9 @@ local lastGridChange = GetGameTimer()
 --- updates the players current grid, if they're in a different grid.
 ---@param forced boolean whether or not to force a grid refresh. default: false
 local function updateZone(forced)
+	if currentRouting ~= 0 then
+		forced = true
+	end
 	local newGrid = getGridZone()
 	if newGrid ~= currentGrid or forced then
 		logger.verbose('Time since last grid change: %s',  (GetGameTimer() - lastGridChange)/1000)


### PR DESCRIPTION
As in my test if we don't force to updateZone one can each the other but the other can't (Sorry for my english).
Forcing updateZone while currentRoutingBucket of the player is different than 0 fix this issue and you'll be able to use routingBuckets and instance the voice to that bucket. (Tested with 5 digits numbers).

Test without external voice server (+200 players): OK (choppy voices when +250 players).
Test using another FXServer as external voice server (+200 players): OK.
Test using murmur as external voice server (+200 players): FAIL.

If you need more info, or have any suggestions, just tell me.

Edit:
Server build: 4194 (External server is same build but in Linux).
Tested with production and canary users (Mixed xd)