### PR TITLE
Use Mumble temporary audio channels

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -11,12 +11,7 @@ function defaultTable(source)
 	}
 end
 
--- temp fix before an actual fix is added
 CreateThread(function()
-    for i = 1, 1024 do
-        MumbleCreateChannel(i)
-    end
-	Wait(5000)
 	if GetConvarInt('voice_zoneRadius', 256) < 256 then
 		logger.warn('The convar \'voice_zoneRadius\' is less then 256 (currently %s, recommended is 256).', GetConvarInt('voice_zoneRadius', 256))
 	end


### PR DESCRIPTION
This PR proposes the discussion about the use of temporary channels instead of pre-creating permanent channels on Mumble. That would give more flexibility to the resource and a reason to use the voice_zoneRadius conVar.

I'm a little bit rusty in Lua, so I'm pretty sure it's possible to improve and optimize this code. The line spacing is not accordingly to the rest of the code just for readability purposes.

I've tested this on server build 4225 and client b2189 canary. In my opinion, the results are relatively fine. But that's something for the maintainer and the community to decide.

Also, I would like to point out that I have no idea if these changes could affect bandwidth usage.

You can see a video of one of my tests [here](https://streamable.com/4zz23r).