### PR TITLE
Add FXDK convar options.

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -32,3 +32,30 @@ provides {
     'toko-voip',
     'tokovoip_script'
 }
+
+convar_category 'PMA-Voice' {
+    "PMA-Voice Configuration Options",
+    {
+        { "Use native audio", "$voice_useNativeAudio", "CV_BOOL", "false" },
+	{ "Use 2D audio", "$voice_use2dAudio", "CV_BOOL", "false" },
+	{ "Use sending range only", "$voice_useSendingRangeOnly", "CV_BOOL", "false" },
+	{ "Enable UI", "$voice_enableUi", "CV_INT", "1" },
+	{ "Enable F11 proximity key", "$voice_enableProximityCycle", "CV_INT", "1" },
+	{ "Proximity cycle key", "$voice_defaultCycle", "CV_STRING", "F11" },
+	{ "Voice volume", "$voice_defaultVolume", "CV_STRING", "0.3" },
+	{ "Enable radios", "$voice_enableRadios", "CV_INT", "1" },
+	{ "Enable phones", "$voice_enablePhones", "CV_INT", "1" },
+	{ "Enable sublix", "$voice_enableSubmix", "CV_INT", "0" },
+        { "Enable radio animation", "$voice_enableRadioAnim", "CV_INT", "0" },
+	{ "Radio key", "$voice_defaultRadio", "CV_STRING", "LALT" },
+	{ "Zone radius", "$voice_zoneRadius", "CV_INT", "256" },
+	{ "Zone refresh rate", "$voice_zoneRefreshRate", "CV_INT", "200" },
+	{ "Enable voice sync (state bags)", "$voice_syncData", "CV_INT", "0" },
+	{ "Allow players to set audio intent", "$voice_allowSetIntent", "CV_INT", "1" },
+	{ "External mumble server address", "$voice_externalAddress", "CV_STRING", "" },
+	{ "External mumble server port", "$voice_externalPort", "CV_INT", "0" },
+	{ "Voice debug mode", "$voice_debugMode", "CV_INT", "0" },
+	{ "Disable players being allowed to join", "$voice_externalDisallowJoin", "CV_INT", "0" },
+	{ "Hide server endpoints in logs", "$voice_hideEndpoints", "CV_INT", "1" },
+    }
+}


### PR DESCRIPTION
Adds the `convar_category` entry to the FXManifest to add convar options that can be modified then applied on build with FXDK.

![image](https://user-images.githubusercontent.com/13007790/129490170-cdfd568c-3d53-4571-be90-c5b09fd23b45.png)
