### PR TITLE
Typo Fix

### DIFF
--- a/client/commands.lua
+++ b/client/commands.lua
@@ -16,7 +16,7 @@ RegisterCommand('vol', function(_, args)
 end)
 
 RegisterCommand('cycleproximity', function()
-	if GetConvarInt('voice_enableProximity', 1) ~= 1 then return end
+	if GetConvarInt('voice_enableProximityCycle', 1) ~= 1 then return end
 	if playerMuted then return end
 
 	local voiceMode = mode


### PR DESCRIPTION
For me the proximity suddenly wasn't working. So I was searching why and I think this is the reason.
The Convar should be voice_enableProximityCycle I think since you reference it like that in the manifest.
And this was a bug that went unnoticed until you now removed the voice_syncData. Correct me if I am wrong about this 😄.
Greetings Ypsilon