### PR TITLE
fix(client/radio): Update UI state when removed from radio

### DIFF
--- a/client/module/radio.lua
+++ b/client/module/radio.lua
@@ -18,6 +18,10 @@ function syncRadioData(radioTable, localPlyRadioName)
 			toggleVoice(tgt, enabled, 'radio')
 		end
 	end
+	sendUIMessage({
+		radioChannel = radioChannel,
+		radioEnabled = radioEnabled
+	})
 	if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
 		radioNames[playerServerId] = localPlyRadioName
 	end
@@ -55,13 +59,19 @@ RegisterNetEvent('pma-voice:addPlayerToRadio', addPlayerToRadio)
 --- event removePlayerFromRadio
 --- removes the player (or self) from the radio
 ---@param plySource number the players server id to remove from the radio.
-function removePlayerFromRadio(plySource)
+function removePlayerFromRadio(plySource, updateUi)
 	if plySource == playerServerId then
 		logger.info('[radio] Left radio %s, cleaning up.', radioChannel)
 		for tgt, _ in pairs(radioData) do
 			if tgt ~= playerServerId then
 				toggleVoice(tgt, false, 'radio')
 			end
+		end
+		if updateUi then
+			sendUIMessage({
+				radioChannel = 0,
+				radioEnabled = radioEnabled
+			})
 		end
 		radioNames = {}
 		radioData = {}
@@ -90,10 +100,6 @@ function setRadioChannel(channel)
 	type_check({channel, "number"})
 	TriggerServerEvent('pma-voice:setPlayerRadio', channel)
 	radioChannel = channel
-	sendUIMessage({
-		radioChannel = channel,
-		radioEnabled = radioEnabled
-	})
 end
 
 --- exports setRadioChannel

--- a/client/module/radio.lua
+++ b/client/module/radio.lua
@@ -59,7 +59,7 @@ RegisterNetEvent('pma-voice:addPlayerToRadio', addPlayerToRadio)
 --- event removePlayerFromRadio
 --- removes the player (or self) from the radio
 ---@param plySource number the players server id to remove from the radio.
-function removePlayerFromRadio(plySource, updateUi)
+function removePlayerFromRadio(plySource)
 	if plySource == playerServerId then
 		logger.info('[radio] Left radio %s, cleaning up.', radioChannel)
 		for tgt, _ in pairs(radioData) do
@@ -67,12 +67,10 @@ function removePlayerFromRadio(plySource, updateUi)
 				toggleVoice(tgt, false, 'radio')
 			end
 		end
-		if updateUi then
-			sendUIMessage({
-				radioChannel = 0,
-				radioEnabled = radioEnabled
-			})
-		end
+		sendUIMessage({
+			radioChannel = 0,
+			radioEnabled = radioEnabled
+		})
 		radioNames = {}
 		radioData = {}
 		playerTargets(MumbleIsPlayerTalking(PlayerId()) and callData or {})

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -51,7 +51,7 @@ exports('overrideRadioNameGetter', overrideRadioNameGetter)
 function addPlayerToRadio(source, radioChannel)
 	if not canJoinChannel(source, radioChannel) then
 		-- remove the player from the radio client side
-		return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source)
+		return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source, true)
 	end
 	logger.verbose('[radio] Added %s to radio %s', source, radioChannel)
 

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -51,7 +51,7 @@ exports('overrideRadioNameGetter', overrideRadioNameGetter)
 function addPlayerToRadio(source, radioChannel)
 	if not canJoinChannel(source, radioChannel) then
 		-- remove the player from the radio client side
-		return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source, true)
+		return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source)
 	end
 	logger.verbose('[radio] Added %s to radio %s', source, radioChannel)
 


### PR DESCRIPTION
This fixes a issue of UI not updating after being [rejected](https://github.com/AvarianKnight/pma-voice/blob/4e73a11f479d3c4d60ab4c4c2d2826c593c3a434/server/module/radio.lua#L52) to join a radio channel.