### PR TITLE
Custom Submix Support

### DIFF
--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -98,15 +98,6 @@ if gameVersion == 'fivem' then
 	submixIndexs['call'] = callEffectId
 end
 
-local submixFunctions = {
-	['radio'] = function(plySource)
-		MumbleSetSubmixForServerId(plySource, submixIndexs['radio'])
-	end,
-	['call'] = function(plySource)
-		MumbleSetSubmixForServerId(plySource, submixIndexs['call'])
-	end
-}
-
 --- export setEffectSubmix
 --- Sets a user defined audio submix for radio and phonecall effects
 ---@param type string that index already exists in submixIndexs and also "call" and "radio" are exist on defaults
@@ -127,9 +118,6 @@ end)
 exports("registerNewSubmixEffect", function(effectIndex, effectId)
 	type_check({effectId, "number"}, {effectIndex, "string"})
 	submixIndexs[effectIndex] = effectId
-	submixFunctions[effectIndex] = function(plySource)
-		MumbleSetSubmixForServerId(plySource, submixIndexs[effectIndex])
-	end
 end)
 
 -- used to prevent a race condition if they talk again afterwards, which would lead to their voice going to default.
@@ -146,9 +134,9 @@ function toggleVoice(plySource, enabled, moduleType)
 		MumbleSetVolumeOverrideByServerId(plySource, enabled and volumes[moduleType])
 		if GetConvarInt('voice_enableSubmix', 1) == 1 and gameVersion == 'fivem' then
 			if moduleType then
-				if submixFunctions[moduleType] then
+				if submixIndexs[moduleType] then
 					disableSubmixReset[plySource] = true
-					submixFunctions[moduleType](plySource)
+					MumbleSetSubmixForServerId(plySource, submixIndexs[moduleType])
 				else
 					logger.warn('toggleVoice got a invalid type %s', moduleType)
 					MumbleSetSubmixForServerId(plySource, -1)

--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -63,11 +63,11 @@ local submixIndexs = {}
 -- 0_freq_hi = 4900.0
 
 if gameVersion == 'fivem' then
-	submixIndexs['radio'] = CreateAudioSubmix('Radio')
-	SetAudioSubmixEffectRadioFx(submixIndexs['radio'], 0)
-	SetAudioSubmixEffectParamInt(submixIndexs['radio'], 0, `default`, 1)
+	radioEffectId = CreateAudioSubmix('Radio')
+	SetAudioSubmixEffectRadioFx(radioEffectId, 0)
+	SetAudioSubmixEffectParamInt(radioEffectId, 0, `default`, 1)
 	SetAudioSubmixOutputVolumes(
-		submixIndexs['radio'], 
+		radioEffectId, 
 		0 , 
 		1.0 --[[ frontLeftVolume ]],
 		0.25 --[[ frontRightVolume ]],
@@ -76,15 +76,16 @@ if gameVersion == 'fivem' then
 		1.0 --[[ channel5Volume ]],
 		1.0 --[[ channel6Volume ]]
 	)
-	AddAudioSubmixOutput(submixIndexs['radio'], 0)
+	AddAudioSubmixOutput(radioEffectId, 0)
+	submixIndexs['radio'] = radioEffectId
 
-	submixIndexs['call'] = CreateAudioSubmix('Call')
-	SetAudioSubmixEffectRadioFx(submixIndexs['call'], 1)
-	SetAudioSubmixEffectParamInt(submixIndexs['call'], 1, `default`, 1)
-	SetAudioSubmixEffectParamFloat(submixIndexs['call'], 1, `freq_low`, 300.0)
-	SetAudioSubmixEffectParamFloat(submixIndexs['call'], 1, `freq_hi`, 6000.0)
+	callEffectId = CreateAudioSubmix('Call')
+	SetAudioSubmixEffectRadioFx(callEffectId, 1)
+	SetAudioSubmixEffectParamInt(callEffectId, 1, `default`, 1)
+	SetAudioSubmixEffectParamFloat(callEffectId, 1, `freq_low`, 300.0)
+	SetAudioSubmixEffectParamFloat(callEffectId, 1, `freq_hi`, 6000.0)
 	SetAudioSubmixOutputVolumes(
-		submixIndexs['call'],
+		callEffectId,
 		0,
 		0.25 --[[ frontLeftVolume ]],
 		1.0 --[[ frontRightVolume ]],
@@ -93,7 +94,8 @@ if gameVersion == 'fivem' then
 		1.0 --[[ channel5Volume ]],
 		1.0 --[[ channel6Volume ]]
 	)
-	AddAudioSubmixOutput(submixIndexs['call'], 1)
+	AddAudioSubmixOutput(callEffectId, 1)
+	submixIndexs['call'] = callEffectId
 end
 
 local submixFunctions = {
@@ -107,7 +109,7 @@ local submixFunctions = {
 
 --- export setEffectSubmix
 --- Sets a user defined audio submix for radio and phonecall effects
----@param type string that index already exists in submixIndexs
+---@param type string that index already exists in submixIndexs and also "call" and "radio" are exist on defaults
 ---@param effectId number submix id returned from CREATE_AUDIO_SUBMIX
 exports("setEffectSubmix", function(type, effectId)
 	type_check({effectId, "number"}, {type, "string"})
@@ -118,11 +120,11 @@ exports("setEffectSubmix", function(type, effectId)
 	end
 end)
 
---- export registerNewEffectSubmix
+--- export registerNewSubmixEffect
 --- Register New audio submix for audio effects
 ---@param effectIndex string the indes it should call the effect
 ---@param effectId number submix id returned from CREATE_AUDIO_SUBMIX
-exports("registerNewEffectSubmix", function(effectIndex, effectId)
+exports("registerNewSubmixEffect", function(effectIndex, effectId)
 	type_check({effectId, "number"}, {effectIndex, "string"})
 	submixIndexs[effectIndex] = effectId
 	submixFunctions[effectIndex] = function(plySource)

--- a/client/module/submix.lua
+++ b/client/module/submix.lua
@@ -1,0 +1,22 @@
+RegisterNetEvent('pma-voice:addPlayerToSubmix', function(plySource, Value)
+	SubmixTable[plySource] = Value
+	if plySource ~= playerServerId then
+		toggleVoice(plySource, Value.enabled, Value.submix)
+	end
+end)
+
+RegisterNetEvent('pma-voice:removePlayerFromSubmix', function(plySource)
+	SubmixTable[plySource] = nil
+	if plySource ~= playerServerId then
+		toggleVoice(plySource, false, SubmixTable[plySource].submix)
+	end
+end)
+
+RegisterNetEvent('pma-voice:syncSubmixData', function(SubmixTable)
+	SubmixTable = SubmixTable
+	for tgt, Value in pairs(SubmixTable) do
+		if tgt ~= playerServerId then
+			toggleVoice(tgt, Value.enabled, Value.submix)
+		end
+	end
+end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,6 +1,7 @@
 voiceData = {}
 radioData = {}
 callData = {}
+SubmixData = {}
 
 function defaultTable(source)
 	handleStateBagInitilization(source)
@@ -107,6 +108,10 @@ AddEventHandler("playerDropped", function()
 
 		if plyData.call ~= 0 then
 			removePlayerFromCall(source, plyData.call)
+		end
+
+		if SubmixData[source] then
+			removePlayerFromSubmix(source)
 		end
 
 		voiceData[source] = nil

--- a/server/module/submix.lua
+++ b/server/module/submix.lua
@@ -17,7 +17,6 @@ addPlayerToSubmix = function(source, submix)
 			submix = submix
 		}
 		SubmixData[source] = PlayerData
-		Player(source).state.radioChannel = radioChannel
 		TriggerClientEvent("pma-voice:addPlayerToSubmix", -1, source, PlayerData)
 	end
 end

--- a/server/module/submix.lua
+++ b/server/module/submix.lua
@@ -1,0 +1,24 @@
+AddEventHandler('playerJoining', function()
+	TriggerClientEvent("pma-voice:syncSubmixData", source, SubmixData)
+end)
+
+removePlayerFromSubmix = function(source)
+	if SubmixData[source] then
+		SubmixData[source] = nil
+		TriggerClientEvent("pma-voice:removePlayerFromSubmix", -1, source)
+	end
+end
+exports('removePlayerFromSubmix', removePlayerFromSubmix)
+
+addPlayerToSubmix = function(source, submix)
+	if not SubmixData[source] then
+		local PlayerData = {
+			enabled = true,
+			submix = submix
+		}
+		SubmixData[source] = PlayerData
+		Player(source).state.radioChannel = radioChannel
+		TriggerClientEvent("pma-voice:addPlayerToSubmix", -1, source, PlayerData)
+	end
+end
+exports('addPlayerToSubmix', addPlayerToSubmix)


### PR DESCRIPTION

- now possible register new submix using export
- now can set custom submix using server export and remove that from list

example client for register new submix
```lua
RegisterCommand("AddSubmix", function(source, args)
	local NewName = "submix2"
	local Index = CreateAudioSubmix(NewName)
	SetAudioSubmixEffectRadioFx(Index, 1)
	SetAudioSubmixEffectParamInt(Index, 1, `default`, 1)
	SetAudioSubmixEffectParamFloat(Index, 1, `freq_low`, 300.0)
	SetAudioSubmixEffectParamFloat(Index, 1, `freq_hi`, 6000.0)
	SetAudioSubmixOutputVolumes(
		Index,
		0,
		0.25 --[[ frontLeftVolume ]],
		1.0 --[[ frontRightVolume ]],
		0.0 --[[ rearLeftVolume ]],
		0.0 --[[ rearRightVolume ]],
		1.0 --[[ channel5Volume ]],
		1.0 --[[ channel6Volume ]]
	)
	AddAudioSubmixOutput(Index, 1)
	print(NewName, Index)
	exports['pma-voice']:registerNewEffectSubmix(NewName, Index)
end)
```

set or remove player submix from server can be like 
```lua
RegisterCommand("addPlayerToSubmix", function(source, args)
	exports['pma-voice']:addPlayerToSubmix(source, tostring(args[1]))
end)
RegisterCommand("removePlayerFromSubmix", function(source, args)
	exports['pma-voice']:removePlayerFromSubmix(source)
end)
```