### PR TITLE
Fix resetting volume when not talking

### DIFF
--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -149,8 +149,8 @@ end
 
 local function updateVolumes(voiceTable, override)
 	for serverId, talking in pairs(voiceTable) do
-		if serverId == playerServerId then goto skip_iter end
-		MumbleSetVolumeOverrideByServerId(serverId, talking and override or -1.0)
+		if not talking then serverId == playerServerId then goto skip_iter end
+		MumbleSetVolumeOverrideByServerId(serverId, override)
 		::skip_iter::
 	end
 end

--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -149,7 +149,7 @@ end
 
 local function updateVolumes(voiceTable, override)
 	for serverId, talking in pairs(voiceTable) do
-		if not talking then serverId == playerServerId then goto skip_iter end
+		if not talking or serverId == playerServerId then goto skip_iter end
 		MumbleSetVolumeOverrideByServerId(serverId, override)
 		::skip_iter::
 	end


### PR DESCRIPTION
Fixed bug introduced in https://github.com/AvarianKnight/pma-voice/commit/f28c909f6fb1b9c99500a782ebfdb611e2f3d7be where the call or radio volume gets reset when not talking. Resulting in call or radio audio being cut off. 