### PR TITLE
chore(client/radio): correct param types

### DIFF
--- a/client/module/radio.lua
+++ b/client/module/radio.lua
@@ -103,7 +103,6 @@ end
 
 --- exports setRadioChannel
 --- sets the local players current radio channel and updates the server
----@param channel number the channel to set the player to, or 0 to remove them.
 exports('setRadioChannel', setRadioChannel)
 -- mumble-voip compatability
 exports('SetRadioChannel', setRadioChannel)
@@ -166,7 +165,7 @@ RegisterCommand('+radiotalk', function()
 				while not HasAnimDictLoaded('random@arrests') do
 					Wait(10)
 				end
-				TaskPlayAnim(PlayerPedId(), "random@arrests", "generic_radio_enter", 8.0, 2.0, -1, 50, 2.0, 0, 0, 0)
+				TaskPlayAnim(PlayerPedId(), "random@arrests", "generic_radio_enter", 8.0, 2.0, -1, 50, 2.0, false, false, false)
 			end
 			CreateThread(function()
 				TriggerEvent("pma-voice:radioActive", true)


### PR DESCRIPTION
`106`: already defined on line `96`
`168`: this native expects boolean for these arguments