### PR TITLE
Removed trigger to inexistant function

### DIFF
--- a/client/module/phone.lua
+++ b/client/module/phone.lua
@@ -59,5 +59,4 @@ end)
 RegisterNetEvent('pma-voice:clSetPlayerCall', function(_callChannel)
 	if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
 	callChannel = _callChannel
-	createCallThread()
 end)


### PR DESCRIPTION
Removed a trigger to `createCallThread` function which doesn't exist