### PR TITLE
feat(audioOcclusion): added audio occlusion in interiors and vehicles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ All of the configs here are set using `setr [voice_configOption] [boolean]`
 
 Native audio will not work on RedM, you will have to use 3d audio.
 
-| ConVar                     | Default | Description                                                   | Parameter(s) |
-|----------------------------|---------|---------------------------------------------------------------|--------------|
-| voice_useNativeAudio       |  false  | Uses the games native audio, will add 3d sound, echo, reverb, and more. **Required for submixs**   | boolean      |
-| voice_use2dAudio           |  false  | Uses 2d audio, will result in same volume sound no matter where they're at until they leave proximity. | boolean      
-| voice_use3dAudio           |  false  | Uses 3d audio | boolean |
-| voice_useSendingRangeOnly  |  false  | Only allows you to hear people within your hear/send range, prevents people from connecting to your mumble server and trolling. | boolean      |
+| ConVar                    | Default | Description                                                                                                                     | Parameter(s) |
+|---------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------|--------------|
+| voice_useNativeAudio      | false   | Uses the games native audio, will add 3d sound, echo, reverb, and more. **Required for submixs**                                | boolean      |
+| voice_use2dAudio          | false   | Uses 2d audio, will result in same volume sound no matter where they're at until they leave proximity.                          | boolean      |
+| voice_use3dAudio          | false   | Uses 3d audio                                                                                                                   | boolean      |
+| voice_useSendingRangeOnly | false   | Only allows you to hear people within your hear/send range, prevents people from connecting to your mumble server and trolling. | boolean      |
 
 # Config
 
@@ -56,40 +56,51 @@ All of the configs here are set using `setr [voice_configOption] [int]` OR `setr
 
 ### General Voice Settings
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_enableUi               |    1    | Enables the built in user interface                            | int          |
-| voice_enableProximityCycle   |    1    | Enables the usage of the F11 proximity key, if disabled players are stuck on the first proximity  | int          |
-| voice_defaultCycle           |   F11   | The default key to cycle the players proximity. You can find a list of valid keys [in the Cfx docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/)                | string       |
-| voice_defaultRadioVolume          |   30   | The default volume to set the radio to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_defaultCallVolume          |   60   | The default volume to set the call to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_defaultVoiceMode  |  2      | Default proximity voice value when player joins server. (Voice Modes; 1:Whisper, 2:Normal, 3:Shouting) | int      |
+| ConVar                     | Default | Description                                                                                                                                                                           | Parameter(s) |
+|----------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| voice_enableUi             | 1       | Enables the built in user interface                                                                                                                                                   | int          |
+| voice_enableProximityCycle | 1       | Enables the usage of the F11 proximity key, if disabled players are stuck on the first proximity                                                                                      | int          |
+| voice_defaultCycle         | F11     | The default key to cycle the players proximity. You can find a list of valid keys [in the Cfx docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/) | string       |
+| voice_defaultRadioVolume   | 30      | The default volume to set the radio to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.*                            | float        |
+| voice_defaultCallVolume    | 60      | The default volume to set the call to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.*                             | float        |
+| voice_defaultVoiceMode     | 2       | Default proximity voice value when player joins server. (Voice Modes; 1:Whisper, 2:Normal, 3:Shouting)                                                                                | int          |
 
 ### Call & Radio
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_enableRadios           |    1    | Enables the radio sub-modules                                 | int          |
-| voice_enableCalls           |    1    | Enables the call sub-modules                                 | int          |
-| voice_enableSubmix      |    1    | Enables the submix which adds a radio/call style submix to their voice **NOTE: Submixs require native audio** | int          |
-| voice_enableRadioAnim        |   0     | Enables (grab shoulder mic) animation while talking on the radio.          | int          |
-| voice_defaultRadio           |   LMENU  | The default key to use the radio. You can find a list of valid keys [in the FiveM docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/)                             | string       |
+| ConVar                | Default | Description                                                                                                                                                               | Parameter(s) |
+|-----------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| voice_enableRadios    | 1       | Enables the radio sub-modules                                                                                                                                             | int          |
+| voice_enableCalls     | 1       | Enables the call sub-modules                                                                                                                                              | int          |
+| voice_enableSubmix    | 1       | Enables the submix which adds a radio/call style submix to their voice **NOTE: Submixs require native audio**                                                             | int          |
+| voice_enableRadioAnim | 0       | Enables (grab shoulder mic) animation while talking on the radio.                                                                                                         | int          |
+| voice_defaultRadio    | LMENU   | The default key to use the radio. You can find a list of valid keys [in the FiveM docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/) | string       |
 
 ### Sync
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_refreshRate   |   200    | How often the UI/Proximity is refreshed | int     |
+| ConVar            | Default | Description                             | Parameter(s) |
+|-------------------|---------|-----------------------------------------|--------------|
+| voice_refreshRate | 200     | How often the UI/Proximity is refreshed | int          |
+
+### Audio Occlusion
+
+| ConVar                                   | Default | Description                                                                                                                                                        | Parameter(s) |
+|------------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| voice_enableAudioOcclusion               | 1       | Enables the audio occlusion sub-module                                                                                                                             | int          |
+| voice_enableInteriorsAudioOcclusion      | 1       | Enable audio occlusion within interiors                                                                                                                            | int          |
+| voice_enableVehicleAudioOcclusion        | 1       | Enable audio occlusion from vehicles                                                                                                                               | int          |
+| voice_audioOcclusionLight                | 0       | Disable the expensive algorithm if there is only 1 room in the interior with lighter but less precise algorithm                                                    | int          |
+| voice_audioOcclusionRefreshRate          | 500     | How often is the audio occlusion refreshed                                                                                                                         | int          |
+| voice_audioOcclusionExpensiveCheckOffset | 0.5     | (float) The offset for the expensive algorithm of audio occlusion, this check is done ONLY IF THE INTERIOR HAS ONLY 1 ROOM (poorly made interiors or single rooms) | float        |
 
 ### External Server & Misc.
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_allowSetIntent         |   1  | Whether or not to allow players to set their audio intents (you can see more [here](https://docs.fivem.net/natives/?_0x6383526B))  | int       |
-| voice_externalAddress        |   none  | The external address to use to connect to the mumble server   | string       |
-| voice_externalPort           |   0     | The external port to use                                      | int          |
-| voice_debugMode              |   0     | 1 for basic logs, 4 for verbose logs                          | int          |
-| voice_externalDisallowJoin   |   0     | Disables players being allowed to join the server, should only be used if you're using a FXServer as a external mumble server. | int          |
-| voice_hideEndpoints     | 1   | Hides the mumble address in logs *NOTE: You should only care to hide this for a external server.* | int        |
+| ConVar                     | Default | Description                                                                                                                       | Parameter(s) |
+|----------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------|--------------|
+| voice_allowSetIntent       | 1       | Whether or not to allow players to set their audio intents (you can see more [here](https://docs.fivem.net/natives/?_0x6383526B)) | int          |
+| voice_externalAddress      | none    | The external address to use to connect to the mumble server                                                                       | string       |
+| voice_externalPort         | 0       | The external port to use                                                                                                          | int          |
+| voice_debugMode            | 0       | 1 for basic logs, 4 for verbose logs                                                                                              | int          |
+| voice_externalDisallowJoin | 0       | Disables players being allowed to join the server, should only be used if you're using a FXServer as a external mumble server.    | int          |
+| voice_hideEndpoints        | 1       | Hides the mumble address in logs *NOTE: You should only care to hide this for a external server.*                                 | int          |
 
 
 
@@ -108,64 +119,77 @@ This would only allow the superadmin group to mute players.
 
 ##### Setters
  
-| Export              | Description                 | Parameter(s) |
-|---------------------|-----------------------------|--------------|
-| [setVoiceProperty](docs/client-setters/setVoiceProperty.md)    | Set config options          | string, any  |
-| [setRadioChannel](docs/client-setters/setRadioChannel.md)     | Set radio channel           | int          |
-| [setCallChannel](docs/client-setters/setCallChannel.md)      | Set call channel            | int          |
-| [setRadioVolume](docs/client-setters/setRadioVolume.md)      | Set radio volume for player | int          |
-| [setCallVolume](docs/client-setters/setCallVolume.md)        | Set call volume for player  | int          |
-| [addPlayerToRadio](docs/client-setters/setRadioChannel.md)      | Set radio channel        | int          |
-| [addPlayerToCall](docs/client-setters/setCallChannel.md)       | Set call channel         | int          |
-| [removePlayerFromRadio](docs/client-setters/removePlayerFromRadio.md) | Remove player from radio |              |
-| [removePlayerFromCall](docs/client-setters/removePlayerFromCall.md)  | Remove player from call  |              |
+| Export                                                                                        | Description                                            | Parameter(s) |
+|-----------------------------------------------------------------------------------------------|--------------------------------------------------------|--------------|
+| [setAudioOcclusion](docs/client-setters/setAudioOcclusion.md)                                 | Set audio occlusion status                             | boolean      |
+| [setInteriorAudioOcclusionDisabled](docs/client-setters/setInteriorAudioOcclusionDisabled.md) | Sets whether the interior has audio occlusion disabled | int          |
+| [setVoiceProperty](docs/client-setters/setVoiceProperty.md)                                   | Set config options                                     | string, any  |
+| [setRadioChannel](docs/client-setters/setRadioChannel.md)                                     | Set radio channel                                      | int          |
+| [setCallChannel](docs/client-setters/setCallChannel.md)                                       | Set call channel                                       | int          |
+| [setRadioVolume](docs/client-setters/setRadioVolume.md)                                       | Set radio volume for player                            | int          |
+| [setCallVolume](docs/client-setters/setCallVolume.md)                                         | Set call volume for player                             | int          |
+| [addPlayerToRadio](docs/client-setters/setRadioChannel.md)                                    | Set radio channel                                      | int          |
+| [addPlayerToCall](docs/client-setters/setCallChannel.md)                                      | Set call channel                                       | int          |
+| [removePlayerFromRadio](docs/client-setters/removePlayerFromRadio.md)                         | Remove player from radio                               |              |
+| [removePlayerFromCall](docs/client-setters/removePlayerFromCall.md)                           | Remove player from call                                |              |
 
 ##### Toggles
 
-| Export              | Description                                            | Parameter(s) |
-|---------------------|--------------------------------------------------------|--------------|
-| toggleMutePlayer    | Toggles the selected player muted for the local client | int          |
+| Export           | Description                                            | Parameter(s) |
+|------------------|--------------------------------------------------------|--------------|
+| toggleMutePlayer | Toggles the selected player muted for the local client | int          |
 
 Supported from mumble-voip / toko-voip
 
-| Export                | Description              | Parameter(s) |
-|-----------------------|--------------------------|--------------|
-| [SetMumbleProperty](docs/client-setters/setVoiceProperty.md)     | Set config options       | string, any  |
-| [SetTokoProperty](docs/client-setters/setVoiceProperty.md)       | Set config options       | string, any  |
-| [SetRadioChannel](docs/client-setters/setRadioChannel.md)       | Set radio channel        | int          |
-| [SetCallChannel](docs/client-setters/setCallChannel.md)        | Set call channel         | int          |
+| Export                                                       | Description        | Parameter(s) |
+|--------------------------------------------------------------|--------------------|--------------|
+| [SetMumbleProperty](docs/client-setters/setVoiceProperty.md) | Set config options | string, any  |
+| [SetTokoProperty](docs/client-setters/setVoiceProperty.md)   | Set config options | string, any  |
+| [SetRadioChannel](docs/client-setters/setRadioChannel.md)    | Set radio channel  | int          |
+| [SetCallChannel](docs/client-setters/setCallChannel.md)      | Set call channel   | int          |
 
 #### Getters
 
-The majority of setters are done through player states, while a small 
+###### State Bags
+You can access the state with `LocalPlayer.state['state bag here']` for the local player or with `Player(serverId).state['state bag here']` for other players
+
+| State Bag                                             | Description                                                  | Return Type |
+|-------------------------------------------------------|--------------------------------------------------------------|-------------|
+| [proximity](docs/state-getters/stateBagGetters.md)    | Returns a table with the mode index, distance, and mode name | table       |
+| [radioChannel](docs/state-getters/stateBagGetters.md) | Returns the players current radio channel, or 0 for none     | int         |
+| [callChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current call channel, or 0 for none      | int         |
+
+###### Exports
+
+| Export                                                                                                  | Description                                                              | Return Type | Parameter(s) |
+|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|-------------|--------------|
+| [getMuffledPlayers](docs/client-getters/getMuffledPlayers.md)                                           | Returns a table with all current muffled players                         | table       |              |
+| [getInteriorsWithDisabledAudioOcclusion](docs/client-getters/getInteriorsWithDisabledAudioOcclusion.md) | Returns a table with all the interiors with the disabled audio occlusion | table       |              |
+| [isPlayerMuffled](docs/client-getters/isPlayerMuffled.md)                                               | Returns true if the player is muffled                                    | boolean     | int          |
+| [isInteriorAudioOcclusionDisabled](docs/client-getters/isInteriorAudioOcclusionDisabled.md)             | Returns true if the interior as the audio occlusion disabled             | boolean     | int          |
 
 
-| State Bag     | Description                                                  | Return Type  |
-|---------------|--------------------------------------------------------------|--------------|
-| [proximity](docs/state-getters/stateBagGetters.md)     | Returns a table with the mode index, distance, and mode name | table        |
-| [radioChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current radio channel, or 0 for none     | int          |
-| [callChannel](docs/state-getters/stateBagGetters.md)   | Returns the players current call channel, or 0 for none      | int          |
 
 #### Events
 
 These are events designed for third-party resource integration. These are emitted only to the current client.
 
-| Event                    | Description                                                  | Event Params   |
-|--------------------------|--------------------------------------------------------------|----------------|
+| Event                                                       | Description                                                | Event Params      |
+|-------------------------------------------------------------|------------------------------------------------------------|-------------------|
 | [pma-voice:settingsCallback](docs/client-getters/events.md) | When emited it will return the current pma-voice settings. | cb(voiceSettings) |
-| [pma-voice:radioActive](docs/client-getters/events.md) | Triggered when the radio is activated / deactivated | boolean |
-| [pma-voice:setTalkingMode](docs/client-getters/events.md) | Triggered on proximity mode change with the voice mode id | int |
+| [pma-voice:radioActive](docs/client-getters/events.md)      | Triggered when the radio is activated / deactivated        | boolean           |
+| [pma-voice:setTalkingMode](docs/client-getters/events.md)   | Triggered on proximity mode change with the voice mode id  | int               |
 
 
 #### Server
 
 ##### Setters
 
-| Export               | Description                          | Parameter(s) |
-|----------------------|--------------------------------------|--------------|
-| [setPlayerRadio](docs/server-setters/setPlayerRadio.md)       | Sets the players radio channel       | int, int     |
-| [setPlayerCall](docs/server-setters/setPlayerCall.md)        | Sets the players call channel        | int, int     |
-| [addChannelCheck](docs/server-setters/addChannelCheck.md)      | Adds a channel check to the players radio channel | int, function |
+| Export                                                    | Description                                       | Parameter(s)  |
+|-----------------------------------------------------------|---------------------------------------------------|---------------|
+| [setPlayerRadio](docs/server-setters/setPlayerRadio.md)   | Sets the players radio channel                    | int, int      |
+| [setPlayerCall](docs/server-setters/setPlayerCall.md)     | Sets the players call channel                     | int, int      |
+| [addChannelCheck](docs/server-setters/addChannelCheck.md) | Adds a channel check to the players radio channel | int, function |
 
 
 ##### Getters
@@ -173,15 +197,15 @@ These are events designed for third-party resource integration. These are emitte
 ###### State Bags
 You can access the state with `Player(source).state['state bag here']`
 
-| State Bag     | Description                                                  | Return Type  |
-|---------------|--------------------------------------------------------------|--------------|
-| [proximity](docs/state-getters/stateBagGetters.md)     | Returns a table with the mode index, distance, and mode name | table        |
-| [radioChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current radio channel, or 0 for none     | int          |
-| [callChannel](docs/state-getters/stateBagGetters.md)   | Returns the players current call channel, or 0 for none      | int          |
-| [voiceIntent](docs/state-getters/stateBagGetters.md) | Returns the players current voice intent, either 'speech' or 'music' | string |
+| State Bag                                             | Description                                                          | Return Type |
+|-------------------------------------------------------|----------------------------------------------------------------------|-------------|
+| [proximity](docs/state-getters/stateBagGetters.md)    | Returns a table with the mode index, distance, and mode name         | table       |
+| [radioChannel](docs/state-getters/stateBagGetters.md) | Returns the players current radio channel, or 0 for none             | int         |
+| [callChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current call channel, or 0 for none              | int         |
+| [voiceIntent](docs/state-getters/stateBagGetters.md)  | Returns the players current voice intent, either 'speech' or 'music' | string      |
 
 ###### Exports
 
-| Export                       | Description                                       | Parameter(s) |
-|------------------------------|---------------------------------------------------|------|
-| [getPlayersInRadioChannel](docs/server-getters/getPlayersInRadioChannel.md)     | Gets the current players in a radio channel       | int  |
+| Export                                                                      | Description                                 | Parameter(s) |
+|-----------------------------------------------------------------------------|---------------------------------------------|--------------|
+| [getPlayersInRadioChannel](docs/server-getters/getPlayersInRadioChannel.md) | Gets the current players in a radio channel | int          |

--- a/client/init/proximity.lua
+++ b/client/init/proximity.lua
@@ -11,7 +11,8 @@ function orig_addProximityCheck(ply)
 	local distance = #(plyCoords - GetEntityCoords(tgtPed))
 	return distance < voiceRange, distance 
 end
-local addProximityCheck = orig_addProximityCheck
+
+addProximityCheck = orig_addProximityCheck
 
 exports("overrideProximityCheck", function(fn)
 	addProximityCheck = fn

--- a/client/module/audioOcclusion.lua
+++ b/client/module/audioOcclusion.lua
@@ -1,0 +1,180 @@
+if gameVersion == 'fivem' and GetConvarInt('voice_enableSubmix', 1) == 1 and GetConvarInt("voice_enableAudioOcclusion", 1) == 1 then
+    local disabledAudioOcclusion = {}
+    local muffledPlayers = {}
+
+    local audioOcclusionEnabled = GetConvarInt("voice_enableAudioOcclusion", 1) == 1
+
+    -- was not done with the internal submix modules since we still have to preserve the calculation of distances, which the "toggleVoice" function overrides
+    local audioOcclusionSubmix = CreateAudioSubmix('audioOcclusion')
+    SetAudioSubmixEffectRadioFx(audioOcclusionSubmix, 0)
+    SetAudioSubmixEffectParamInt(audioOcclusionSubmix, 0, `default`, 1)
+    SetAudioSubmixEffectParamFloat(audioOcclusionSubmix, 0, `freq_low`, 0.0)
+    SetAudioSubmixEffectParamFloat(audioOcclusionSubmix, 0, `freq_hi`, 850.0)
+    SetAudioSubmixEffectParamFloat(audioOcclusionSubmix, 0, `rm_mix`, 0.00)
+    SetAudioSubmixEffectParamFloat(audioOcclusionSubmix, 0, `o_freq_lo`, 0.0)
+    SetAudioSubmixEffectParamFloat(audioOcclusionSubmix, 0, `o_freq_hi`, 850.0)
+    AddAudioSubmixOutput(audioOcclusionSubmix, 0)
+   
+    RaycastHitSomething = function(coords, coords2, flags, ignore)
+        local rayHandle = StartShapeTestLosProbe(coords, coords2, flags, ignore)
+        local code, hit = GetShapeTestResult(rayHandle)
+        
+        while code == 1 do
+            code, hit = GetShapeTestResult(rayHandle)
+            Citizen.Wait(1)
+        end
+    
+        return hit == 1
+    end
+    
+    ExpensiveLosCheck = function(entity1, entity2, flags)
+        local coords1 = GetEntityCoords(entity1)
+        local coords2 = GetEntityCoords(entity2)
+        local center = RaycastHitSomething(coords1, coords2, flags, entity1)
+        local losCheckOffset = tonumber(GetConvar("voice_audioOcclusionExpensiveCheckOffset", "0.5")) -- we convert string to number to allow floats
+
+        -- we do one check at a time to limit the raycasts performed as much as possible
+        if center then
+            local leftCoords = GetOffsetFromEntityInWorldCoords(entity1, losCheckOffset, 0.0, 0.0)
+            local left = RaycastHitSomething(leftCoords, coords2, flags, entity1)
+            
+            if left then
+                local rightCoords = GetOffsetFromEntityInWorldCoords(entity1, -losCheckOffset, 0.0, 0.0)
+                local right = RaycastHitSomething(rightCoords, coords2, flags, entity1)
+                
+                if right then
+                    local topCoords = GetOffsetFromEntityInWorldCoords(entity1, 0.0, 0.0, losCheckOffset)
+                    local top = RaycastHitSomething(topCoords, coords2, flags, entity1)
+    
+                    if top then
+                        return false -- If all 4 raycasts fail (center, left, right, top) then it means that there is probably a large enough object that is blocking
+                    end
+                end
+            end
+        end
+    
+        return true
+    end
+    
+    DoInteriorChecks = function(interior, currentPlayerRoom, playerRoom, currentPlayer, player)
+        local roomCount = GetInteriorRoomCount(interior) - 1
+                            
+        if roomCount > 1 then
+            if currentPlayerRoom ~= playerRoom and not HasEntityClearLosToEntity(currentPlayer, player, 17) then -- If the players are in different rooms and the 2 players cannot see each other (this prevent audio occlusion when opening a door)
+                return true
+            else
+                return false
+            end
+        else
+            if GetConvarInt("voice_audioOcclusionLight", 0) == 1 then
+                return not HasEntityClearLosToEntity(currentPlayer, player, 17)
+            else
+                -- If there are no rooms inside the interior (poorly made interiors or single rooms) 
+                -- we shoot 4 beams from the current player to the other player to not perform audio occlusion even when there is only one pillar blocking the two players. 
+                return not ExpensiveLosCheck(currentPlayer, player, 17)
+            end
+        end
+    end
+    
+    DoVehicleChecks = function(player)
+        local vehicle = GetVehiclePedIsIn(player)
+    
+        if vehicle > 0 and DoesVehicleHaveRoof(vehicle) then
+            local doors = GetNumberOfVehicleDoors(vehicle)
+    
+            for i=0, 6 do
+                if DoesVehicleHaveDoor(vehicle, i) then
+                    if IsVehicleDoorDamaged(vehicle, i) or IsVehicleDoorFullyOpen(vehicle, i) or GetVehicleDoorAngleRatio(vehicle, i) > 0.0 then
+                        return false
+                    end
+                end
+            end
+            
+            if AreAllVehicleWindowsIntact(vehicle) then
+                return true
+            end
+            
+            return false
+        else
+            return false
+        end
+    end
+
+    Citizen.CreateThread(function()
+        local voiceRange = GetConvar('voice_useNativeAudio', 'false') == 'true' and proximity * 3 or proximity
+    
+        while true do
+            muffledPlayers = {}
+
+            if audioOcclusionEnabled then
+                local player = PlayerPedId()
+                local playerRoom = GetRoomKeyFromEntity(player)
+                local players = GetActivePlayers()
+        
+                if #players > 1 then
+                    for k,v in ipairs(players) do
+                        local otherPlayer = GetPlayerPed(v)
+                        
+                        if player ~= otherPlayer then
+                            local needToCheck, distance = addProximityCheck(v)
+    
+                            if needToCheck then
+                                local interior = GetInteriorFromEntity(otherPlayer)
+                                local playerServerId = GetPlayerServerId(v)
+                                local audioOcclusion = nil
+
+                                if interior > 0 and not disabledAudioOcclusion[interior] and GetConvarInt("voice_enableInteriorsAudioOcclusion", 1) == 1 then
+                                    local otherPlayerRoom = GetRoomKeyFromEntity(otherPlayer)
+                                    
+                                    audioOcclusion = DoInteriorChecks(interior, playerRoom, otherPlayerRoom, otherPlayer, player)
+                                else
+                                    if GetConvarInt("voice_enableVehicleAudioOcclusion", 1) == 1 then
+                                        audioOcclusion = DoVehicleChecks(otherPlayer)
+                                    end
+                                end
+
+                                if audioOcclusion then
+                                    muffledPlayers[playerServerId] = true
+                                    MumbleSetSubmixForServerId(playerServerId, audioOcclusionSubmix)
+                                else
+                                    muffledPlayers[playerServerId] = nil
+                                    MumbleSetSubmixForServerId(playerServerId, -1)
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+
+            Citizen.Wait(GetConvarInt('voice_audioOcclusionRefreshRate', 500))
+        end
+    end)
+    
+    exports("setAudioOcclusion", function(active)
+        for id,v in pairs(muffledPlayers) do
+            MumbleSetSubmixForServerId(id, -1)
+        end
+
+        audioOcclusionEnabled = active
+    end)
+
+    exports("getMuffledPlayers", function()
+        return muffledPlayers
+    end)
+
+    exports("isPlayerMuffled", function(serverId)
+        return muffledPlayers[serverId]
+    end)
+    
+    exports("setInteriorAudioOcclusionDisabled", function(interior, active)
+        disabledAudioOcclusion[interior] = active
+    end)
+
+    exports("isInteriorAudioOcclusionDisabled", function(interiorId)
+        return disabledAudioOcclusion[interior] == true
+    end)
+
+    exports("getInteriorsWithDisabledAudioOcclusion", function()
+        return disabledAudioOcclusion
+    end)
+end

--- a/docs/client-getters/getInteriorsWithDisabledAudioOcclusion.md
+++ b/docs/client-getters/getInteriorsWithDisabledAudioOcclusion.md
@@ -1,0 +1,14 @@
+## getInteriorsWithDisabledAudioOcclusion
+
+## Description
+
+Returns a table with all the interiors with the disabled audio occlusion
+
+```lua
+local disabledInteriors = exports['pma-voice']:getInteriorsWithDisabledAudioOcclusion()
+print(json.encode(disabledInteriors)) -- {1538445: true, 9304534: true, -134356: true} (interiorId: disabled)
+
+for interiorId, _ in pairs(disabledInteriors) do
+    print(interiorId.." has audio occlusion turned off.")
+end
+```

--- a/docs/client-getters/getMuffledPlayers.md
+++ b/docs/client-getters/getMuffledPlayers.md
@@ -1,0 +1,14 @@
+## getMuffledPlayers
+
+## Description
+
+Returns a table with all current muffled players
+
+```lua
+local muffledPlayers = exports['pma-voice']:getMuffledPlayers()
+print(json.encode(muffledPlayers)) -- {10: true, 1: true, 32: true} (serverId: active)
+
+for serverId, _ in pairs(muffledPlayers) do
+    print(serverId.." its muffled")
+end
+```

--- a/docs/client-getters/isInteriorAudioOcclusionDisabled.md
+++ b/docs/client-getters/isInteriorAudioOcclusionDisabled.md
@@ -1,0 +1,18 @@
+## isInteriorAudioOcclusionDisabled
+
+## Description
+
+Returns true if the interior as the audio occlusion disabled
+
+## Parameters
+
+* **interiorId**: The id of the interior to which we need to set audio occlusion disabled or not
+
+```lua
+local interiorId = GetInteriorAtCoords(vector3(436.31, -981.93, 30.75)) -- Los santos police station
+local audioOcclusionDisabled = exports['pma-voice']:isInteriorAudioOcclusionDisabled(interiorId)
+
+if audioOcclusionDisabled then
+    print("Audio occlusion in the police station is turned off.")
+end
+```

--- a/docs/client-getters/isPlayerMuffled.md
+++ b/docs/client-getters/isPlayerMuffled.md
@@ -1,0 +1,20 @@
+## isPlayerMuffled
+
+## Description
+
+Returns true if the player is muffled
+
+## Parameters
+
+* **serverId**: The server id of the player we need to check
+
+```lua
+local player = GetPlayerFromIndex(2) -- we get a random nearby player
+local serverId = GetPlayerServerId(player) -- we get the server id of that player
+
+local muffled = exports['pma-voice']:isPlayerMuffled(serverId)
+
+if muffled then
+    print(GetPlayerName(player).." is muffled")
+end
+```

--- a/docs/client-setters/setAudioOcclusion.md
+++ b/docs/client-setters/setAudioOcclusion.md
@@ -1,0 +1,14 @@
+## setAudioOcclusion
+
+## Description
+
+Enable or disable the audio occlusion for the client 
+
+## Parameters
+
+* **active**: Whether to enable or disable audio occlusion
+
+```lua
+exports['pma-voice']:setAudioOcclusion(true) -- Audio occlusion will be present in the interiors and vehicles
+exports['pma-voice']:setAudioOcclusion(false) -- Audio occlusion will NOT be present in the interiors and vehicles
+```

--- a/docs/client-setters/setInteriorAudioOcclusionDisabled.md
+++ b/docs/client-setters/setInteriorAudioOcclusionDisabled.md
@@ -1,0 +1,15 @@
+## setInteriorAudioOcclusionDisabled
+
+## Description
+
+Sets whether the interior has audio occlusion disabled
+
+## Parameters
+
+* **interiorId**: The id of the interior to which we need to set audio occlusion disabled or not
+
+```lua
+local interiorId = GetInteriorAtCoords(vector3(436.31, -981.93, 30.75)) -- Los santos police station
+
+exports['pma-voice']:setInteriorAudioOcclusionDisabled(interiorId, true) -- Audio occlusion will NOT be present in this interior.
+```


### PR DESCRIPTION
I created an audio occlusion system to muffle voices when they are over walls in interiors or when someone from a car is talking to someone outside. 
This should add even more realism and extend pma to be able to reach SaltyChat features and give a valid substitute