### PR TITLE
Add ability to load files in custom_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ﻿.idea
 .vscode
+# server/custom_modules
+# client/custom_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 ﻿.idea
 .vscode
-# server/custom_modules
-# client/custom_modules

--- a/client/commands.lua
+++ b/client/commands.lua
@@ -1,80 +1,81 @@
 local wasProximityDisabledFromOverride = false
 disableProximityCycle = false
 RegisterCommand('setvoiceintent', function(source, args)
-	if GetConvarInt('voice_allowSetIntent', 1) == 1 then
-		local intent = args[1]
-		if intent == 'speech' then
-			MumbleSetAudioInputIntent(`speech`)
-		elseif intent == 'music' then
-			MumbleSetAudioInputIntent(`music`)
-		end
-		LocalPlayer.state:set('voiceIntent', intent, true)
-	end
+    if GetConvarInt('voice_allowSetIntent', 1) == 1 then
+        local intent = args[1]
+        if intent == 'speech' then
+            MumbleSetAudioInputIntent(`speech`)
+        elseif intent == 'music' then
+            MumbleSetAudioInputIntent(`music`)
+        end
+        LocalPlayer.state:set('voiceIntent', intent, true)
+    end
 end)
 TriggerEvent('chat:addSuggestion', '/setvoiceintent', 'Sets the players voice intent', {
-    { name = "intent", help = "speech is default and enables noise suppression & high pass filter, music disables both of these." },
+    { name = "intent",
+        help = "speech is default and enables noise suppression & high pass filter, music disables both of these." },
 })
 
 -- TODO: Better implementation of this?
 RegisterCommand('vol', function(_, args)
-	if not args[1] then return end
-	setVolume(tonumber(args[1]))
+    if not args[1] then return end
+    setVolume(tonumber(args[1]))
 end)
 TriggerEvent('chat:addSuggestion', '/vol', 'Sets the radio/phone volume', {
     { name = "volume", help = "A range between 1-100 on how loud you want them to be" },
 })
 
 exports('setAllowProximityCycleState', function(state)
-	type_check({state, "boolean"})
-	disableProximityCycle = state
+    type_check({ state, "boolean" })
+    disableProximityCycle = state
 end)
 
 function setProximityState(proximityRange, isCustom)
-	local voiceModeData = Cfg.voiceModes[mode]
-	MumbleSetTalkerProximity(proximityRange + 0.0)
-	LocalPlayer.state:set('proximity', {
-		index = mode,
-		distance = proximityRange,
-		mode = isCustom and "Custom" or voiceModeData[2],
-	}, true)
-	sendUIMessage({
-		-- JS expects this value to be - 1, "custom" voice is on the last index
-		voiceMode = isCustom and #Cfg.voiceModes or mode - 1
-	})
+    local voiceModeData = Cfg.voiceModes[mode]
+    MumbleSetTalkerProximity(proximityRange + 0.0)
+    LocalPlayer.state:set('proximity', {
+        index = mode,
+        distance = proximityRange,
+        mode = isCustom and "Custom" or voiceModeData[2],
+    }, true)
+    sendUIMessage({
+        -- JS expects this value to be - 1, "custom" voice is on the last index
+        voiceMode = isCustom and #Cfg.voiceModes or mode - 1
+    })
 end
 
 exports("overrideProximityRange", function(range, disableCycle)
-	type_check({range, "number"})
-	setProximityState(range, true)
-	if disableCycle then
-		disableProximityCycle = true
-		wasProximityDisabledFromOverride = true
-	end
+    type_check({ range, "number" })
+    setProximityState(range, true)
+    if disableCycle then
+        disableProximityCycle = true
+        wasProximityDisabledFromOverride = true
+    end
 end)
 
 exports("clearProximityOverride", function()
-	local voiceModeData = Cfg.voiceModes[mode]
-	setProximityState(voiceModeData[1], false)
-	if wasProximityDisabledFromOverride then
-		disableProximityCycle = false
-	end
+    local voiceModeData = Cfg.voiceModes[mode]
+    setProximityState(voiceModeData[1], false)
+    if wasProximityDisabledFromOverride then
+        disableProximityCycle = false
+    end
 end)
 
 RegisterCommand('cycleproximity', function()
-	-- Proximity is either disabled, or manually overwritten.
-	if GetConvarInt('voice_enableProximityCycle', 1) ~= 1 or disableProximityCycle then return end
-	local newMode = mode + 1
+    -- Proximity is either disabled, or manually overwritten.
+    if GetConvarInt('voice_enableProximityCycle', 1) ~= 1 or disableProximityCycle then return end
+    local newMode = mode + 1
 
-	-- If we're within the range of our voice modes, allow the increase, otherwise reset to the first state
-	if newMode <= #Cfg.voiceModes then
-		mode = newMode
-	else
-		mode = 1
-	end
+    -- If we're within the range of our voice modes, allow the increase, otherwise reset to the first state
+    if newMode <= #Cfg.voiceModes then
+        mode = newMode
+    else
+        mode = 1
+    end
 
-	setProximityState(Cfg.voiceModes[mode][1], false)
-	TriggerEvent('pma-voice:setTalkingMode', mode)
+    setProximityState(Cfg.voiceModes[mode][1], false)
+    TriggerEvent('pma-voice:setTalkingMode', mode)
 end, false)
 if gameVersion == 'fivem' then
-	RegisterKeyMapping('cycleproximity', 'Cycle Proximity', 'keyboard', GetConvar('voice_defaultCycle', 'F11'))
+    RegisterKeyMapping('cycleproximity', 'Cycle Proximity', 'keyboard', GetConvar('voice_defaultCycle', 'F11'))
 end

--- a/client/custom_modules/.gitignore
+++ b/client/custom_modules/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/client/events.lua
+++ b/client/events.lua
@@ -1,42 +1,45 @@
 function handleInitialState()
-	local voiceModeData = Cfg.voiceModes[mode]
-	MumbleSetTalkerProximity(voiceModeData[1] + 0.0)
-	MumbleClearVoiceTarget(voiceTarget)
-	MumbleSetVoiceTarget(voiceTarget)
-	MumbleSetVoiceChannel(playerServerId)
+    local voiceModeData = Cfg.voiceModes[mode]
+    MumbleSetTalkerProximity(voiceModeData[1] + 0.0)
+    MumbleClearVoiceTarget(voiceTarget)
+    MumbleSetVoiceTarget(voiceTarget)
+    MumbleSetVoiceChannel(playerServerId)
 
-	while MumbleGetVoiceChannelFromServerId(playerServerId) ~= playerServerId do
-		Wait(250)
-		MumbleSetVoiceChannel(playerServerId)
-	end
+    while MumbleGetVoiceChannelFromServerId(playerServerId) ~= playerServerId do
+        Wait(250)
+        MumbleSetVoiceChannel(playerServerId)
+    end
 
-	MumbleAddVoiceTargetChannel(voiceTarget, playerServerId)
+    MumbleAddVoiceTargetChannel(voiceTarget, playerServerId)
 
-	addNearbyPlayers()
+    addNearbyPlayers()
 end
 
 AddEventHandler('mumbleConnected', function(address, isReconnecting)
-	logger.info('Connected to mumble server with address of %s, is this a reconnect %s', GetConvarInt('voice_hideEndpoints', 1) == 1 and 'HIDDEN' or address, isReconnecting)
+    logger.info('Connected to mumble server with address of %s, is this a reconnect %s',
+    GetConvarInt('voice_hideEndpoints', 1) == 1 and 'HIDDEN' or address, isReconnecting)
 
-	logger.log('Connecting to mumble, setting targets.')
-	-- don't try to set channel instantly, we're still getting data.
-	local voiceModeData = Cfg.voiceModes[mode]
-	LocalPlayer.state:set('proximity', {
-		index = mode,
-		distance =  voiceModeData[1],
-		mode = voiceModeData[2],
-	}, true)
+    logger.log('Connecting to mumble, setting targets.')
+    -- don't try to set channel instantly, we're still getting data.
+    local voiceModeData = Cfg.voiceModes[mode]
+    LocalPlayer.state:set('proximity', {
+        index = mode,
+        distance = voiceModeData[1],
+        mode = voiceModeData[2],
+    }, true)
 
-	handleInitialState()
+    handleInitialState()
 
-	logger.log('Finished connection logic')
+    logger.log('Finished connection logic')
 end)
 
 AddEventHandler('mumbleDisconnected', function(address)
-	logger.info('Disconnected from mumble server with address of %s', GetConvarInt('voice_hideEndpoints', 1) == 1 and 'HIDDEN' or address)
+    logger.info('Disconnected from mumble server with address of %s',
+    GetConvarInt('voice_hideEndpoints', 1) == 1 and 'HIDDEN' or address)
 end)
 
 -- TODO: Convert the last Cfg to a Convar, while still keeping it simple.
 AddEventHandler('pma-voice:settingsCallback', function(cb)
-	cb(Cfg)
+    cb(Cfg)
 end)
+

--- a/client/init/init.lua
+++ b/client/init/init.lua
@@ -1,46 +1,46 @@
-
 AddEventHandler('onClientResourceStart', function(resource)
-	if resource ~= GetCurrentResourceName() then
-		return
-	end
-	print('Starting script initialization')
+    if resource ~= GetCurrentResourceName() then
+        return
+    end
+    print('Starting script initialization')
 
-	-- Some people modify pma-voice and mess up the resource Kvp, which means that if someone
-	-- joins another server that has pma-voice, it will error out, this will catch and fix the kvp.
-	local success = pcall(function()
-		local micClicksKvp = GetResourceKvpString('pma-voice_enableMicClicks')
-		if not micClicksKvp then
-			SetResourceKvp('pma-voice_enableMicClicks', "true")
-		else
-			if micClicksKvp ~= 'true' and micClicksKvp ~= 'false' then
-				error('Invalid Kvp, throwing error for automatic fix')
-			end
-			micClicks = micClicksKvp
-		end
-	end)
+    -- Some people modify pma-voice and mess up the resource Kvp, which means that if someone
+    -- joins another server that has pma-voice, it will error out, this will catch and fix the kvp.
+    local success = pcall(function()
+        local micClicksKvp = GetResourceKvpString('pma-voice_enableMicClicks')
+        if not micClicksKvp then
+            SetResourceKvp('pma-voice_enableMicClicks', "true")
+        else
+            if micClicksKvp ~= 'true' and micClicksKvp ~= 'false' then
+                error('Invalid Kvp, throwing error for automatic fix')
+            end
+            micClicks = micClicksKvp
+        end
+    end)
 
-	if not success then
-		logger.warn('Failed to load resource Kvp, likely was inappropriately modified by another server, resetting the Kvp.')
-		SetResourceKvp('pma-voice_enableMicClicks', "true")
-		micClicks = 'true'
-	end
-	sendUIMessage({
-		uiEnabled = GetConvarInt("voice_enableUi", 1) == 1,
-		voiceModes = json.encode(Cfg.voiceModes),
-		voiceMode = mode - 1
-	})
+    if not success then
+        logger.warn(
+        'Failed to load resource Kvp, likely was inappropriately modified by another server, resetting the Kvp.')
+        SetResourceKvp('pma-voice_enableMicClicks', "true")
+        micClicks = 'true'
+    end
+    sendUIMessage({
+        uiEnabled = GetConvarInt("voice_enableUi", 1) == 1,
+        voiceModes = json.encode(Cfg.voiceModes),
+        voiceMode = mode - 1
+    })
 
-	local radioChannel = LocalPlayer.state.radioChannel or 0
-	local callChannel = LocalPlayer.state.callChannel or 0
+    local radioChannel = LocalPlayer.state.radioChannel or 0
+    local callChannel = LocalPlayer.state.callChannel or 0
 
-	-- Reinitialize channels if they're set.
-	if radioChannel ~= 0 then
-		setRadioChannel(radioChannel)
-	end
+    -- Reinitialize channels if they're set.
+    if radioChannel ~= 0 then
+        setRadioChannel(radioChannel)
+    end
 
-	if callChannel ~= 0 then
-		setCallChannel(callChannel)
-	end
+    if callChannel ~= 0 then
+        setCallChannel(callChannel)
+    end
 
-	print('Script initialization finished.')
+    print('Script initialization finished.')
 end)

--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -2,9 +2,9 @@ local mutedPlayers = {}
 
 -- we can't use GetConvarInt because its not a integer, and theres no way to get a float... so use a hacky way it is!
 local volumes = {
-	-- people are setting this to 1 instead of 1.0 and expecting it to work.
-	['radio'] = GetConvarInt('voice_defaultRadioVolume', 60) / 100,
-	['call'] = GetConvarInt('voice_defaultCallVolume', 60) / 100,
+    -- people are setting this to 1 instead of 1.0 and expecting it to work.
+    ['radio'] = GetConvarInt('voice_defaultRadioVolume', 60) / 100,
+    ['call'] = GetConvarInt('voice_defaultCallVolume', 60) / 100,
 }
 
 radioEnabled, radioPressed, mode = true, false, GetConvarInt('voice_defaultVoiceMode', 2)
@@ -16,38 +16,38 @@ submixIndicies = {}
 ---@param volume number between 0 and 100
 ---@param volumeType string the volume type (currently radio & call) to set the volume of (opt)
 function setVolume(volume, volumeType)
-	type_check({volume, "number"})
-	local volume = volume / 100
-	
-	if volumeType then
-		local volumeTbl = volumes[volumeType]
-		if volumeTbl then
-			LocalPlayer.state:set(volumeType, volume, true)
-			volumes[volumeType] = volume
-			resyncVolume(volumeType, volume)
-		else
-			error(('setVolume got a invalid volume type %s'):format(volumeType))
-		end
-	else
-		for volumeType, _ in pairs(volumes) do
-			volumes[volumeType] = volume
-			LocalPlayer.state:set(volumeType, volume, true)
-		end
-		resyncVolume("all", volume)
-	end
+    type_check({ volume, "number" })
+    local volume = volume / 100
+
+    if volumeType then
+        local volumeTbl = volumes[volumeType]
+        if volumeTbl then
+            LocalPlayer.state:set(volumeType, volume, true)
+            volumes[volumeType] = volume
+            resyncVolume(volumeType, volume)
+        else
+            error(('setVolume got a invalid volume type %s'):format(volumeType))
+        end
+    else
+        for volumeType, _ in pairs(volumes) do
+            volumes[volumeType] = volume
+            LocalPlayer.state:set(volumeType, volume, true)
+        end
+        resyncVolume("all", volume)
+    end
 end
 
 exports('setRadioVolume', function(vol)
-	setVolume(vol, 'radio')
+    setVolume(vol, 'radio')
 end)
 exports('getRadioVolume', function()
-	return volumes['radio']
+    return volumes['radio']
 end)
 exports("setCallVolume", function(vol)
-	setVolume(vol, 'call')
+    setVolume(vol, 'call')
 end)
 exports('getCallVolume', function()
-	return volumes['call']
+    return volumes['call']
 end)
 
 
@@ -95,9 +95,9 @@ submixIndicies['call'] = callEffectId
 -- the callback is sent the effectSlot it can register to, not sure if this is needed, but its here for safety
 exports("registerCustomSubmix", function(callback)
     local submixTable = callback()
-    type_check({submixTable, "table"})
+    type_check({ submixTable, "table" })
     local submixName, submixId = submixTable[1], submixTable[2]
-    type_check({submixName, "string"}, {submixId, "number"})
+    type_check({ submixName, "string" }, { submixId, "number" })
     logger.info("Creating submix %s with submixId %s", submixName, submixId)
     submixIndicies[submixName] = submixId
 end)
@@ -108,20 +108,20 @@ TriggerEvent("pma-voice:registerCustomSubmixes")
 ---@param type string either "call" or "radio"
 ---@param effectId number submix id returned from CREATE_AUDIO_SUBMIX
 exports("setEffectSubmix", function(type, effectId)
-	type_check({type, "string"}, {effectId, "number"})
-	if submixIndicies[type] then
-		submixIndicies[type] = effectId
-	end
+    type_check({ type, "string" }, { effectId, "number" })
+    if submixIndicies[type] then
+        submixIndicies[type] = effectId
+    end
 end)
 
 function restoreDefaultSubmix(plyServerId)
-	local submix = Player(plyServerId).state.submix
-	local submixEffect = submixIndicies[submix]
-	if not submix or not submixEffect then
-		MumbleSetSubmixForServerId(plyServerId, -1)
-		return
-	end
-	MumbleSetSubmixForServerId(plyServerId, submixEffect)
+    local submix = Player(plyServerId).state.submix
+    local submixEffect = submixIndicies[submix]
+    if not submix or not submixEffect then
+        MumbleSetSubmixForServerId(plyServerId, -1)
+        return
+    end
+    MumbleSetSubmixForServerId(plyServerId, submixEffect)
 end
 
 -- used to prevent a race condition if they talk again afterwards, which would lead to their voice going to default.
@@ -132,54 +132,54 @@ local disableSubmixReset = {}
 ---@param enabled boolean if the players voice is getting activated or deactivated
 ---@param moduleType string the volume & submix to use for the voice.
 function toggleVoice(plySource, enabled, moduleType)
-	if mutedPlayers[plySource] then return end
-	logger.verbose('[main] Updating %s to talking: %s with submix %s', plySource, enabled, moduleType)
-	local distance = currentTargets[plySource]
-	if enabled and (not distance or distance > 4.0) then
-		MumbleSetVolumeOverrideByServerId(plySource, enabled and volumes[moduleType])
-		if GetConvarInt('voice_enableSubmix', 1) == 1 then
-			if moduleType then
-				disableSubmixReset[plySource] = true
-				if submixIndicies[moduleType] then
-					MumbleSetSubmixForServerId(plySource, submixIndicies[moduleType])
-				end
-			else
-				restoreDefaultSubmix(plySource)
-			end
-		end
-	elseif not enabled then
-		if GetConvarInt('voice_enableSubmix', 1) == 1 then
-			-- garbage collect it
-			disableSubmixReset[plySource] = nil
-			SetTimeout(250, function()
-				if not disableSubmixReset[plySource] then
-					restoreDefaultSubmix(plySource)
-				end
-			end)
-		end
-		MumbleSetVolumeOverrideByServerId(plySource, -1.0)
-	end
+    if mutedPlayers[plySource] then return end
+    logger.verbose('[main] Updating %s to talking: %s with submix %s', plySource, enabled, moduleType)
+    local distance = currentTargets[plySource]
+    if enabled and (not distance or distance > 4.0) then
+        MumbleSetVolumeOverrideByServerId(plySource, enabled and volumes[moduleType])
+        if GetConvarInt('voice_enableSubmix', 1) == 1 then
+            if moduleType then
+                disableSubmixReset[plySource] = true
+                if submixIndicies[moduleType] then
+                    MumbleSetSubmixForServerId(plySource, submixIndicies[moduleType])
+                end
+            else
+                restoreDefaultSubmix(plySource)
+            end
+        end
+    elseif not enabled then
+        if GetConvarInt('voice_enableSubmix', 1) == 1 then
+            -- garbage collect it
+            disableSubmixReset[plySource] = nil
+            SetTimeout(250, function()
+                if not disableSubmixReset[plySource] then
+                    restoreDefaultSubmix(plySource)
+                end
+            end)
+        end
+        MumbleSetVolumeOverrideByServerId(plySource, -1.0)
+    end
 end
 
 local function updateVolumes(voiceTable, override)
-	for serverId, talking in pairs(voiceTable) do
-		if serverId == playerServerId then goto skip_iter end
-		MumbleSetVolumeOverrideByServerId(serverId, talking and override or -1.0)
-		::skip_iter::
-	end
+    for serverId, talking in pairs(voiceTable) do
+        if serverId == playerServerId then goto skip_iter end
+        MumbleSetVolumeOverrideByServerId(serverId, talking and override or -1.0)
+        ::skip_iter::
+    end
 end
 
 --- resyncs the call/radio/etc volume to the new volume
 ---@param volumeType any
 function resyncVolume(volumeType, newVolume)
-	if volumeType == "all" then
-		resyncVolume("radio", newVolume)
-		resyncVolume("call", newVolume)
-	elseif volumeType == "radio" then
-		updateVolumes(radioData, newVolume)
-	elseif volumeType == "call" then
-		updateVolumes(callData, newVolume)
-	end
+    if volumeType == "all" then
+        resyncVolume("radio", newVolume)
+        resyncVolume("call", newVolume)
+    elseif volumeType == "radio" then
+        updateVolumes(radioData, newVolume)
+    elseif volumeType == "call" then
+        updateVolumes(callData, newVolume)
+    end
 end
 
 --- function playerTargets
@@ -188,61 +188,62 @@ end
 ---@diagnostic disable-next-line: undefined-doc-param
 ---@param targets table expects multiple tables to be sent over
 function playerTargets(...)
-	local targets = {...}
-	local addedPlayers = {
-		[playerServerId] = true
-	}
+    local targets = { ... }
+    local addedPlayers = {
+        [playerServerId] = true
+    }
 
-	for i = 1, #targets do
-		for id, _ in pairs(targets[i]) do
-			-- we don't want to log ourself, or listen to ourself
-			if addedPlayers[id] and id ~= playerServerId then
-				logger.verbose('[main] %s is already target don\'t re-add', id)
-				goto skip_loop
-			end
-			if not addedPlayers[id] then
-				logger.verbose('[main] Adding %s as a voice target', id)
-				addedPlayers[id] = true
-				MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
-			end
-			::skip_loop::
-		end
-	end
+    for i = 1, #targets do
+        for id, _ in pairs(targets[i]) do
+            -- we don't want to log ourself, or listen to ourself
+            if addedPlayers[id] and id ~= playerServerId then
+                logger.verbose('[main] %s is already target don\'t re-add', id)
+                goto skip_loop
+            end
+            if not addedPlayers[id] then
+                logger.verbose('[main] Adding %s as a voice target', id)
+                addedPlayers[id] = true
+                MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
+            end
+            ::skip_loop::
+        end
+    end
 end
 
 --- function playMicClicks
 ---plays the mic click if the player has them enabled.
----@param clickType boolean whether to play the 'on' or 'off' click. 
+---@param clickType boolean whether to play the 'on' or 'off' click.
 function playMicClicks(clickType)
-	if micClicks ~= 'true' then return logger.verbose("Not playing mic clicks because client has them disabled") end
-	-- TODO: Add customizable radio click volumes
-	sendUIMessage({
-		sound = (clickType and "audio_on" or "audio_off"),
-		volume = (clickType and 0.1 or 0.03)
-	})
+    if micClicks ~= 'true' then return logger.verbose("Not playing mic clicks because client has them disabled") end
+    -- TODO: Add customizable radio click volumes
+    sendUIMessage({
+        sound = (clickType and "audio_on" or "audio_off"),
+        volume = (clickType and 0.1 or 0.03)
+    })
 end
 
 --- check if player is muted
 exports('isPlayerMuted', function(source)
-	return mutedPlayers[source]
+    return mutedPlayers[source]
 end)
 
 --- getter for mutedPlayers
 exports('getMutedPlayers', function()
-	return mutedPlayers
+    return mutedPlayers
 end)
 
 --- toggles the targeted player muted
 ---@param source number the player to mute
 function toggleMutePlayer(source)
-	if mutedPlayers[source] then
-		mutedPlayers[source] = nil
-		MumbleSetVolumeOverrideByServerId(source, -1.0)
-	else
-		mutedPlayers[source] = true
-		MumbleSetVolumeOverrideByServerId(source, 0.0)
-	end
+    if mutedPlayers[source] then
+        mutedPlayers[source] = nil
+        MumbleSetVolumeOverrideByServerId(source, -1.0)
+    else
+        mutedPlayers[source] = true
+        MumbleSetVolumeOverrideByServerId(source, 0.0)
+    end
 end
+
 exports('toggleMutePlayer', toggleMutePlayer)
 
 --- function setVoiceProperty
@@ -250,17 +251,18 @@ exports('toggleMutePlayer', toggleMutePlayer)
 ---@param type string what voice property you want to change (only takes 'radioEnabled' and 'micClicks')
 ---@param value any the value to set the type to.
 function setVoiceProperty(type, value)
-	if type == "radioEnabled" then
-		radioEnabled = value
-		sendUIMessage({
-			radioEnabled = value
-		})
-	elseif type == "micClicks" then
-		local val = tostring(value)
-		micClicks = val
-		SetResourceKvp('pma-voice_enableMicClicks', val)
-	end
+    if type == "radioEnabled" then
+        radioEnabled = value
+        sendUIMessage({
+            radioEnabled = value
+        })
+    elseif type == "micClicks" then
+        local val = tostring(value)
+        micClicks = val
+        SetResourceKvp('pma-voice_enableMicClicks', val)
+    end
 end
+
 exports('setVoiceProperty', setVoiceProperty)
 -- compatibility
 exports('SetMumbleProperty', setVoiceProperty)
@@ -271,31 +273,31 @@ exports('SetTokoProperty', setVoiceProperty)
 local externalAddress = ''
 local externalPort = 0
 CreateThread(function()
-	while true do
-		Wait(500)
-		-- only change if what we have doesn't match the cache
-		if GetConvar('voice_externalAddress', '') ~= externalAddress or GetConvarInt('voice_externalPort', 0) ~= externalPort then
-			externalAddress = GetConvar('voice_externalAddress', '')
-			externalPort = GetConvarInt('voice_externalPort', 0)
-			MumbleSetServerAddress(GetConvar('voice_externalAddress', ''), GetConvarInt('voice_externalPort', 0))
-		end
-	end
+    while true do
+        Wait(500)
+        -- only change if what we have doesn't match the cache
+        if GetConvar('voice_externalAddress', '') ~= externalAddress or GetConvarInt('voice_externalPort', 0) ~= externalPort then
+            externalAddress = GetConvar('voice_externalAddress', '')
+            externalPort = GetConvarInt('voice_externalPort', 0)
+            MumbleSetServerAddress(GetConvar('voice_externalAddress', ''), GetConvarInt('voice_externalPort', 0))
+        end
+    end
 end)
 
 
 if gameVersion == 'redm' then
-	CreateThread(function()
-		while true do
-			if IsControlJustPressed(0, 0xA5BDCD3C --[[ Right Bracket ]]) then
-				ExecuteCommand('cycleproximity')
-			end
-			if IsControlJustPressed(0, 0x430593AA --[[ Left Bracket ]]) then
-				ExecuteCommand('+radiotalk')
-			elseif IsControlJustReleased(0, 0x430593AA --[[ Left Bracket ]]) then
-				ExecuteCommand('-radiotalk')
-			end
+    CreateThread(function()
+        while true do
+            if IsControlJustPressed(0, 0xA5BDCD3C --[[ Right Bracket ]]) then
+                ExecuteCommand('cycleproximity')
+            end
+            if IsControlJustPressed(0, 0x430593AA --[[ Left Bracket ]]) then
+                ExecuteCommand('+radiotalk')
+            elseif IsControlJustReleased(0, 0x430593AA --[[ Left Bracket ]]) then
+                ExecuteCommand('-radiotalk')
+            end
 
-			Wait(0)
-		end
-	end)
+            Wait(0)
+        end
+    end)
 end

--- a/client/init/proximity.lua
+++ b/client/init/proximity.lua
@@ -6,100 +6,101 @@ proximity = MumbleGetTalkerProximity()
 currentTargets = {}
 
 function orig_addProximityCheck(ply)
-	local tgtPed = GetPlayerPed(ply)
-	local voiceRange = GetConvar('voice_useNativeAudio', 'false') == 'true' and proximity * 3 or proximity
-	local distance = #(plyCoords - GetEntityCoords(tgtPed))
-	return distance < voiceRange, distance 
+    local tgtPed = GetPlayerPed(ply)
+    local voiceRange = GetConvar('voice_useNativeAudio', 'false') == 'true' and proximity * 3 or proximity
+    local distance = #(plyCoords - GetEntityCoords(tgtPed))
+    return distance < voiceRange, distance
 end
+
 local addProximityCheck = orig_addProximityCheck
 
 exports("overrideProximityCheck", function(fn)
-	addProximityCheck = fn
+    addProximityCheck = fn
 end)
 
 exports("resetProximityCheck", function()
-	addProximityCheck = orig_addProximityCheck
+    addProximityCheck = orig_addProximityCheck
 end)
 
 function addNearbyPlayers()
-	if disableUpdates then return end
-	-- update here so we don't have to update every call of addProximityCheck
-	plyCoords = GetEntityCoords(PlayerPedId())
-	proximity = MumbleGetTalkerProximity()
-	currentTargets = {}
-	MumbleClearVoiceTargetChannels(voiceTarget)
-	if LocalPlayer.state.disableProximity then return end
-	MumbleAddVoiceChannelListen(playerServerId)
-	MumbleAddVoiceTargetChannel(voiceTarget, playerServerId)
+    if disableUpdates then return end
+    -- update here so we don't have to update every call of addProximityCheck
+    plyCoords = GetEntityCoords(PlayerPedId())
+    proximity = MumbleGetTalkerProximity()
+    currentTargets = {}
+    MumbleClearVoiceTargetChannels(voiceTarget)
+    if LocalPlayer.state.disableProximity then return end
+    MumbleAddVoiceChannelListen(playerServerId)
+    MumbleAddVoiceTargetChannel(voiceTarget, playerServerId)
 
     for source, _ in pairs(callData) do
         if source ~= playerServerId then
             MumbleAddVoiceTargetChannel(voiceTarget, source)
-		end
+        end
     end
 
 
-	local players = GetActivePlayers()
-	for i = 1, #players do
-		local ply = players[i]
-		local serverId = GetPlayerServerId(ply)
-		local shouldAdd, distance = addProximityCheck(ply)
-		if shouldAdd then
-			-- if distance then
-			-- 	currentTargets[serverId] = distance
-			-- else
-			-- 	-- backwards compat, maybe remove in v7 
-			-- 	currentTargets[serverId] = 15.0
-			-- end
-			-- logger.verbose('Added %s as a voice target', serverId)
-			MumbleAddVoiceTargetChannel(voiceTarget, serverId)
-		end
-	end
+    local players = GetActivePlayers()
+    for i = 1, #players do
+        local ply = players[i]
+        local serverId = GetPlayerServerId(ply)
+        local shouldAdd, distance = addProximityCheck(ply)
+        if shouldAdd then
+            -- if distance then
+            -- 	currentTargets[serverId] = distance
+            -- else
+            -- 	-- backwards compat, maybe remove in v7
+            -- 	currentTargets[serverId] = 15.0
+            -- end
+            -- logger.verbose('Added %s as a voice target', serverId)
+            MumbleAddVoiceTargetChannel(voiceTarget, serverId)
+        end
+    end
 end
 
 function setSpectatorMode(enabled)
-	logger.info('Setting spectate mode to %s', enabled)
-	isListenerEnabled = enabled
-	local players = GetActivePlayers()
-	if isListenerEnabled then
-		for i = 1, #players do
-			local ply = players[i]
-			local serverId = GetPlayerServerId(ply)
-			if serverId == playerServerId then goto skip_loop end
-			logger.verbose("Adding %s to listen table", serverId)
-			MumbleAddVoiceChannelListen(serverId)
-			::skip_loop::
-		end
-	else
-		for i = 1, #players do
-			local ply = players[i]
-			local serverId = GetPlayerServerId(ply)
-			if serverId == playerServerId then goto skip_loop end
-			logger.verbose("Removing %s from listen table", serverId)
-			MumbleRemoveVoiceChannelListen(serverId)
-			::skip_loop::
-		end
-	end
+    logger.info('Setting spectate mode to %s', enabled)
+    isListenerEnabled = enabled
+    local players = GetActivePlayers()
+    if isListenerEnabled then
+        for i = 1, #players do
+            local ply = players[i]
+            local serverId = GetPlayerServerId(ply)
+            if serverId == playerServerId then goto skip_loop end
+            logger.verbose("Adding %s to listen table", serverId)
+            MumbleAddVoiceChannelListen(serverId)
+            ::skip_loop::
+        end
+    else
+        for i = 1, #players do
+            local ply = players[i]
+            local serverId = GetPlayerServerId(ply)
+            if serverId == playerServerId then goto skip_loop end
+            logger.verbose("Removing %s from listen table", serverId)
+            MumbleRemoveVoiceChannelListen(serverId)
+            ::skip_loop::
+        end
+    end
 end
 
 RegisterNetEvent('onPlayerJoining', function(serverId)
-	if isListenerEnabled then
-		MumbleAddVoiceChannelListen(serverId)
-		logger.verbose("Adding %s to listen table", serverId)
-	end
+    if isListenerEnabled then
+        MumbleAddVoiceChannelListen(serverId)
+        logger.verbose("Adding %s to listen table", serverId)
+    end
 end)
 
 RegisterNetEvent('onPlayerDropped', function(serverId)
-	if isListenerEnabled then
-		MumbleRemoveVoiceChannelListen(serverId)
-		logger.verbose("Removing %s from listen table", serverId)
-	end
+    if isListenerEnabled then
+        MumbleRemoveVoiceChannelListen(serverId)
+        logger.verbose("Removing %s from listen table", serverId)
+    end
 end)
 
 local listenerOverride = false
 exports("setListenerOverride", function(enabled)
-	type_check({enabled, "boolean"})
-	listenerOverride = enabled
+    type_check({ enabled, "boolean" })
+    listenerOverride = enabled
 end)
 
 -- cache talking status so we only send a nui message when its not the same as what it was before
@@ -107,103 +108,105 @@ local lastTalkingStatus = false
 local lastRadioStatus = false
 local voiceState = "proximity"
 CreateThread(function()
-	TriggerEvent('chat:addSuggestion', '/muteply', 'Mutes the player with the specified id', {
-		{ name = "player id", help = "the player to toggle mute" },
-		{ name = "duration", help = "(opt) the duration the mute in seconds (default: 900)" }
-	})
-	while true do
-		-- wait for mumble to reconnect
-		while not MumbleIsConnected() do
-			Wait(100)
-		end
-		-- Leave the check here as we don't want to do any of this logic 
-		if GetConvarInt('voice_enableUi', 1) == 1 then
-			local curTalkingStatus = MumbleIsPlayerTalking(PlayerId()) == 1
-			if lastRadioStatus ~= radioPressed or lastTalkingStatus ~= curTalkingStatus then
-				lastRadioStatus = radioPressed
-				lastTalkingStatus = curTalkingStatus
-				sendUIMessage({
-					usingRadio = lastRadioStatus,
-					talking = lastTalkingStatus
-				})
-			end
-		end
+    TriggerEvent('chat:addSuggestion', '/muteply', 'Mutes the player with the specified id', {
+        { name = "player id", help = "the player to toggle mute" },
+        { name = "duration",  help = "(opt) the duration the mute in seconds (default: 900)" }
+    })
+    while true do
+        -- wait for mumble to reconnect
+        while not MumbleIsConnected() do
+            Wait(100)
+        end
+        -- Leave the check here as we don't want to do any of this logic
+        if GetConvarInt('voice_enableUi', 1) == 1 then
+            local curTalkingStatus = MumbleIsPlayerTalking(PlayerId()) == 1
+            if lastRadioStatus ~= radioPressed or lastTalkingStatus ~= curTalkingStatus then
+                lastRadioStatus = radioPressed
+                lastTalkingStatus = curTalkingStatus
+                sendUIMessage({
+                    usingRadio = lastRadioStatus,
+                    talking = lastTalkingStatus
+                })
+            end
+        end
 
-		if voiceState == "proximity" then
-			addNearbyPlayers()
-			-- What a name, wowza
-			local cam = GetConvarInt("voice_disableAutomaticListenerOnCamera", 0) ~= 1 and GetRenderingCam() or -1
-			local isSpectating = NetworkIsInSpectatorMode() or cam ~= -1
-			if not isListenerEnabled and (isSpectating or listenerOverride) then
-				setSpectatorMode(true)
-			elseif isListenerEnabled and not isSpectating and not listenerOverride then
-				setSpectatorMode(false)
-			end
-		end
+        if voiceState == "proximity" then
+            addNearbyPlayers()
+            -- What a name, wowza
+            local cam = GetConvarInt("voice_disableAutomaticListenerOnCamera", 0) ~= 1 and GetRenderingCam() or -1
+            local isSpectating = NetworkIsInSpectatorMode() or cam ~= -1
+            if not isListenerEnabled and (isSpectating or listenerOverride) then
+                setSpectatorMode(true)
+            elseif isListenerEnabled and not isSpectating and not listenerOverride then
+                setSpectatorMode(false)
+            end
+        end
 
-		Wait(GetConvarInt('voice_refreshRate', 200))
-	end
+        Wait(GetConvarInt('voice_refreshRate', 200))
+    end
 end)
 
 exports("setVoiceState", function(_voiceState, channel)
-	if _voiceState ~= "proximity" and _voiceState ~= "channel" then
-		logger.error("Didn't get a proper voice state, expected proximity or channel, got %s", _voiceState)
-	end
-	voiceState = _voiceState
-	if voiceState == "channel" then
-		type_check({channel, "number"})
-		-- 65535 is the highest a client id can go, so we add that to the base channel so we don't manage to get onto a players channel
-		channel = channel + 65535
-		MumbleSetVoiceChannel(channel)
-		while MumbleGetVoiceChannelFromServerId(playerServerId) ~= channel do
-			Wait(250)
-		end
-		MumbleAddVoiceTargetChannel(voiceTarget, channel)
-	elseif voiceState == "proximity" then
-		handleInitialState()
-	end
+    if _voiceState ~= "proximity" and _voiceState ~= "channel" then
+        logger.error("Didn't get a proper voice state, expected proximity or channel, got %s", _voiceState)
+    end
+    voiceState = _voiceState
+    if voiceState == "channel" then
+        type_check({ channel, "number" })
+        -- 65535 is the highest a client id can go, so we add that to the base channel so we don't manage to get onto a players channel
+        channel = channel + 65535
+        MumbleSetVoiceChannel(channel)
+        while MumbleGetVoiceChannelFromServerId(playerServerId) ~= channel do
+            Wait(250)
+        end
+        MumbleAddVoiceTargetChannel(voiceTarget, channel)
+    elseif voiceState == "proximity" then
+        handleInitialState()
+    end
 end)
 
 
 AddEventHandler("onClientResourceStop", function(resource)
-	if type(addProximityCheck) == "table" then
-		local proximityCheckRef = addProximityCheck.__cfx_functionReference
-		if proximityCheckRef then
-			local isResource = string.match(proximityCheckRef, resource)
-			if isResource then
-				addProximityCheck = orig_addProximityCheck
-				logger.warn('Reset proximity check to default, the original resource [%s] which provided the function restarted', resource)
-			end
-		end
-	end
+    if type(addProximityCheck) == "table" then
+        local proximityCheckRef = addProximityCheck.__cfx_functionReference
+        if proximityCheckRef then
+            local isResource = string.match(proximityCheckRef, resource)
+            if isResource then
+                addProximityCheck = orig_addProximityCheck
+                logger.warn(
+                'Reset proximity check to default, the original resource [%s] which provided the function restarted',
+                resource)
+            end
+        end
+    end
 end)
 
 exports("addVoiceMode", function(distance, name)
-	for i = 1, #Cfg.voiceModes do
-		local voiceMode = Cfg.voiceModes[i]
-		if voiceMode[2] == name then
-			logger.verbose("Already had %s, overwritting instead", name)
-			voiceMode[1] = distance
-			return
-		end
-	end
-	Cfg.voiceModes[#Cfg.voiceModes + 1] = {distance, name}
+    for i = 1, #Cfg.voiceModes do
+        local voiceMode = Cfg.voiceModes[i]
+        if voiceMode[2] == name then
+            logger.verbose("Already had %s, overwritting instead", name)
+            voiceMode[1] = distance
+            return
+        end
+    end
+    Cfg.voiceModes[#Cfg.voiceModes + 1] = { distance, name }
 end)
 
 exports("removeVoiceMode", function(name)
-	for i = 1, #Cfg.voiceModes do
-		local voiceMode = Cfg.voiceModes[i]
-		if voiceMode[2] == name then
-			table.remove(Cfg.voiceModes, i)
-			-- Reset our current range if we had it
-			if mode == i then
-				local newMode = Cfg.voiceModes[1]
-				mode = 1
-				setProximityState(newMode[mode], false)
-			end
-			return true
-		end
-	end
+    for i = 1, #Cfg.voiceModes do
+        local voiceMode = Cfg.voiceModes[i]
+        if voiceMode[2] == name then
+            table.remove(Cfg.voiceModes, i)
+            -- Reset our current range if we had it
+            if mode == i then
+                local newMode = Cfg.voiceModes[1]
+                mode = 1
+                setProximityState(newMode[mode], false)
+            end
+            return true
+        end
+    end
 
-	return false
+    return false
 end)

--- a/client/init/proximity.lua
+++ b/client/init/proximity.lua
@@ -12,7 +12,7 @@ function orig_addProximityCheck(ply)
     return distance < voiceRange, distance
 end
 
-local addProximityCheck = orig_addProximityCheck
+addProximityCheck = orig_addProximityCheck
 
 exports("overrideProximityCheck", function(fn)
     addProximityCheck = fn

--- a/client/module/phone.lua
+++ b/client/module/phone.lua
@@ -1,62 +1,62 @@
 local callChannel = 0
 
 RegisterNetEvent('pma-voice:syncCallData', function(callTable, channel)
-	callData = callTable
-	for tgt, _ in pairs(callTable) do
-		if tgt ~= playerServerId then
-			toggleVoice(tgt, true, 'call')
-		end
-	end
+    callData = callTable
+    for tgt, _ in pairs(callTable) do
+        if tgt ~= playerServerId then
+            toggleVoice(tgt, true, 'call')
+        end
+    end
 end)
 
 RegisterNetEvent('pma-voice:addPlayerToCall', function(plySource)
-	toggleVoice(plySource, true, 'call')
-	callData[plySource] = true
+    toggleVoice(plySource, true, 'call')
+    callData[plySource] = true
 end)
 
 RegisterNetEvent('pma-voice:removePlayerFromCall', function(plySource)
-	if plySource == playerServerId then
-		for tgt, _ in pairs(callData) do
-			if tgt ~= playerServerId then
-				toggleVoice(tgt, false, 'call')
-			end
-		end
-		callData = {}
-		MumbleClearVoiceTargetPlayers(voiceTarget)
-		playerTargets(radioPressed and radioData or {}, callData)
-	else
-		callData[plySource] = nil
-		toggleVoice(plySource, false, 'call')
-		if MumbleIsPlayerTalking(PlayerId()) then
-			MumbleClearVoiceTargetPlayers(voiceTarget)
-			playerTargets(radioPressed and radioData or {}, callData)
-		end
-	end
+    if plySource == playerServerId then
+        for tgt, _ in pairs(callData) do
+            if tgt ~= playerServerId then
+                toggleVoice(tgt, false, 'call')
+            end
+        end
+        callData = {}
+        MumbleClearVoiceTargetPlayers(voiceTarget)
+        playerTargets(radioPressed and radioData or {}, callData)
+    else
+        callData[plySource] = nil
+        toggleVoice(plySource, false, 'call')
+        if MumbleIsPlayerTalking(PlayerId()) then
+            MumbleClearVoiceTargetPlayers(voiceTarget)
+            playerTargets(radioPressed and radioData or {}, callData)
+        end
+    end
 end)
 
 function setCallChannel(channel)
-	if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
-	TriggerServerEvent('pma-voice:setPlayerCall', channel)
-	callChannel = channel
-	sendUIMessage({
-		callInfo = channel
-	})
+    if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
+    TriggerServerEvent('pma-voice:setPlayerCall', channel)
+    callChannel = channel
+    sendUIMessage({
+        callInfo = channel
+    })
 end
 
 exports('setCallChannel', setCallChannel)
 exports('SetCallChannel', setCallChannel)
 
 exports('addPlayerToCall', function(_call)
-	local call = tonumber(_call)
-	if call then
-		setCallChannel(call)
-	end
+    local call = tonumber(_call)
+    if call then
+        setCallChannel(call)
+    end
 end)
 exports('removePlayerFromCall', function()
-	setCallChannel(0)
+    setCallChannel(0)
 end)
 
 RegisterNetEvent('pma-voice:clSetPlayerCall', function(_callChannel)
-	if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
-	callChannel = _callChannel
+    if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
+    callChannel = _callChannel
 end)

--- a/client/module/radio.lua
+++ b/client/module/radio.lua
@@ -7,26 +7,27 @@ local disableRadioAnim = false
 ---@param radioTable table the table of the current players on the radio
 ---@param localPlyRadioName string the local players name
 function syncRadioData(radioTable, localPlyRadioName)
-	radioData = radioTable
-	logger.info('[radio] Syncing radio table.')
-	if GetConvarInt('voice_debugMode', 0) >= 4 then
-		print('-------- RADIO TABLE --------')
-		tPrint(radioData)
-		print('-----------------------------')
-	end
-	for tgt, enabled in pairs(radioTable) do
-		if tgt ~= playerServerId then
-			toggleVoice(tgt, enabled, 'radio')
-		end
-	end
-	sendUIMessage({
-		radioChannel = radioChannel,
-		radioEnabled = radioEnabled
-	})
-	if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
-		radioNames[playerServerId] = localPlyRadioName
-	end
+    radioData = radioTable
+    logger.info('[radio] Syncing radio table.')
+    if GetConvarInt('voice_debugMode', 0) >= 4 then
+        print('-------- RADIO TABLE --------')
+        tPrint(radioData)
+        print('-----------------------------')
+    end
+    for tgt, enabled in pairs(radioTable) do
+        if tgt ~= playerServerId then
+            toggleVoice(tgt, enabled, 'radio')
+        end
+    end
+    sendUIMessage({
+        radioChannel = radioChannel,
+        radioEnabled = radioEnabled
+    })
+    if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
+        radioNames[playerServerId] = localPlyRadioName
+    end
 end
+
 RegisterNetEvent('pma-voice:syncRadioData', syncRadioData)
 
 --- event setTalkingOnRadio
@@ -38,70 +39,73 @@ function setTalkingOnRadio(plySource, enabled)
     if not callData[plySource] then
         toggleVoice(plySource, enabled, 'radio')
     end
-	radioData[plySource] = enabled
-	playMicClicks(enabled)
+    radioData[plySource] = enabled
+    playMicClicks(enabled)
 end
+
 RegisterNetEvent('pma-voice:setTalkingOnRadio', setTalkingOnRadio)
 
 --- event addPlayerToRadio
 --- adds a player onto the radio.
 ---@param plySource number the players server id to add to the radio.
 function addPlayerToRadio(plySource, plyRadioName)
-	radioData[plySource] = false
-	if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
-		radioNames[plySource] = plyRadioName
-	end
-	if radioPressed then
-		logger.info('[radio] %s joined radio %s while we were talking, adding them to targets', plySource, radioChannel)
-		playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
-	else
-		logger.info('[radio] %s joined radio %s', plySource, radioChannel)
-	end
+    radioData[plySource] = false
+    if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
+        radioNames[plySource] = plyRadioName
+    end
+    if radioPressed then
+        logger.info('[radio] %s joined radio %s while we were talking, adding them to targets', plySource, radioChannel)
+        playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
+    else
+        logger.info('[radio] %s joined radio %s', plySource, radioChannel)
+    end
 end
+
 RegisterNetEvent('pma-voice:addPlayerToRadio', addPlayerToRadio)
 
 --- event removePlayerFromRadio
 --- removes the player (or self) from the radio
 ---@param plySource number the players server id to remove from the radio.
 function removePlayerFromRadio(plySource)
-	if plySource == playerServerId then
-		logger.info('[radio] Left radio %s, cleaning up.', radioChannel)
-		for tgt, _ in pairs(radioData) do
-			if tgt ~= playerServerId then
-				toggleVoice(tgt, false, 'radio')
-			end
-		end
-		sendUIMessage({
-			radioChannel = 0,
-			radioEnabled = radioEnabled
-		})
-		radioNames = {}
-		radioData = {}
-		playerTargets(MumbleIsPlayerTalking(PlayerId()) and callData or {})
-	else
-		toggleVoice(plySource, false , 'radio')
-		if radioPressed then
-			logger.info('[radio] %s left radio %s while we were talking, updating targets.', plySource, radioChannel)
-			playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
-		else
-			logger.info('[radio] %s has left radio %s', plySource, radioChannel)
-		end
-		radioData[plySource] = nil
-		if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
-			radioNames[plySource] = nil
-		end
-	end
+    if plySource == playerServerId then
+        logger.info('[radio] Left radio %s, cleaning up.', radioChannel)
+        for tgt, _ in pairs(radioData) do
+            if tgt ~= playerServerId then
+                toggleVoice(tgt, false, 'radio')
+            end
+        end
+        sendUIMessage({
+            radioChannel = 0,
+            radioEnabled = radioEnabled
+        })
+        radioNames = {}
+        radioData = {}
+        playerTargets(MumbleIsPlayerTalking(PlayerId()) and callData or {})
+    else
+        toggleVoice(plySource, false, 'radio')
+        if radioPressed then
+            logger.info('[radio] %s left radio %s while we were talking, updating targets.', plySource, radioChannel)
+            playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
+        else
+            logger.info('[radio] %s has left radio %s', plySource, radioChannel)
+        end
+        radioData[plySource] = nil
+        if GetConvarInt("voice_syncPlayerNames", 0) == 1 then
+            radioNames[plySource] = nil
+        end
+    end
 end
+
 RegisterNetEvent('pma-voice:removePlayerFromRadio', removePlayerFromRadio)
 
 --- function setRadioChannel
 --- sets the local players current radio channel and updates the server
 ---@param channel number the channel to set the player to, or 0 to remove them.
 function setRadioChannel(channel)
-	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
-	type_check({channel, "number"})
-	TriggerServerEvent('pma-voice:setPlayerRadio', channel)
-	radioChannel = channel
+    if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
+    type_check({ channel, "number" })
+    TriggerServerEvent('pma-voice:setPlayerRadio', channel)
+    radioChannel = channel
 end
 
 --- exports setRadioChannel
@@ -113,30 +117,30 @@ exports('SetRadioChannel', setRadioChannel)
 --- exports removePlayerFromRadio
 --- sets the local players current radio channel and updates the server
 exports('removePlayerFromRadio', function()
-	setRadioChannel(0)
+    setRadioChannel(0)
 end)
 
 --- exports addPlayerToRadio
 --- sets the local players current radio channel and updates the server
 ---@param _radio number the channel to set the player to, or 0 to remove them.
 exports('addPlayerToRadio', function(_radio)
-	local radio = tonumber(_radio)
-	if radio then
-		setRadioChannel(radio)
-	end
+    local radio = tonumber(_radio)
+    if radio then
+        setRadioChannel(radio)
+    end
 end)
 
 --- exports toggleRadioAnim
 --- toggles whether the client should play radio anim or not, if the animation should be played or notvaliddance
 exports('toggleRadioAnim', function()
-	disableRadioAnim = not disableRadioAnim
-	TriggerEvent('pma-voice:toggleRadioAnim', disableRadioAnim)
+    disableRadioAnim = not disableRadioAnim
+    TriggerEvent('pma-voice:toggleRadioAnim', disableRadioAnim)
 end)
 
 -- exports disableRadioAnim
 --- returns whether the client is undercover or not
 exports('getRadioAnimState', function()
-	return disableRadioAnim
+    return disableRadioAnim
 end)
 
 --- check if the player is dead
@@ -145,67 +149,69 @@ end)
 --- but you can integrate the below state bag to your death resources.
 --- LocalPlayer.state:set('isDead', true or false, false)
 function isDead()
-	if LocalPlayer.state.isDead then
-		return true
-	elseif IsPlayerDead(PlayerId()) then
-		return true
-	end
+    if LocalPlayer.state.isDead then
+        return true
+    elseif IsPlayerDead(PlayerId()) then
+        return true
+    end
 end
 
 RegisterCommand('+radiotalk', function()
-	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
-	if isDead() or LocalPlayer.state.disableRadio then return end
+    if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
+    if isDead() or LocalPlayer.state.disableRadio then return end
 
-	if not radioPressed and radioEnabled then
-		if radioChannel > 0 then
-			logger.info('[radio] Start broadcasting, update targets and notify server.')
-			playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
-			TriggerServerEvent('pma-voice:setTalkingOnRadio', true)
-			radioPressed = true
-			playMicClicks(true)
-			if GetConvarInt('voice_enableRadioAnim', 0) == 1 and not (GetConvarInt('voice_disableVehicleRadioAnim', 0) == 1 and IsPedInAnyVehicle(PlayerPedId(), false)) and not disableRadioAnim then
-				RequestAnimDict('random@arrests')
-				while not HasAnimDictLoaded('random@arrests') do
-					Wait(10)
-				end
-				TaskPlayAnim(PlayerPedId(), "random@arrests", "generic_radio_enter", 8.0, 2.0, -1, 50, 2.0, false, false, false)
-			end
-			CreateThread(function()
-				TriggerEvent("pma-voice:radioActive", true)
-				while radioPressed and not LocalPlayer.state.disableRadio do
-					Wait(0)
-					SetControlNormal(0, 249, 1.0)
-					SetControlNormal(1, 249, 1.0)
-					SetControlNormal(2, 249, 1.0)
-				end
-			end)
-		end
-	end
+    if not radioPressed and radioEnabled then
+        if radioChannel > 0 then
+            logger.info('[radio] Start broadcasting, update targets and notify server.')
+            playerTargets(radioData, MumbleIsPlayerTalking(PlayerId()) and callData or {})
+            TriggerServerEvent('pma-voice:setTalkingOnRadio', true)
+            radioPressed = true
+            playMicClicks(true)
+            if GetConvarInt('voice_enableRadioAnim', 0) == 1 and not (GetConvarInt('voice_disableVehicleRadioAnim', 0) == 1 and IsPedInAnyVehicle(PlayerPedId(), false)) and not disableRadioAnim then
+                RequestAnimDict('random@arrests')
+                while not HasAnimDictLoaded('random@arrests') do
+                    Wait(10)
+                end
+                TaskPlayAnim(PlayerPedId(), "random@arrests", "generic_radio_enter", 8.0, 2.0, -1, 50, 2.0, false, false,
+                false)
+            end
+            CreateThread(function()
+                TriggerEvent("pma-voice:radioActive", true)
+                while radioPressed and not LocalPlayer.state.disableRadio do
+                    Wait(0)
+                    SetControlNormal(0, 249, 1.0)
+                    SetControlNormal(1, 249, 1.0)
+                    SetControlNormal(2, 249, 1.0)
+                end
+            end)
+        end
+    end
 end, false)
 
 RegisterCommand('-radiotalk', function()
-	if (radioChannel > 0 or radioEnabled) and radioPressed then
-		radioPressed = false
-		MumbleClearVoiceTargetPlayers(voiceTarget)
-		playerTargets(MumbleIsPlayerTalking(PlayerId()) and callData or {})
-		TriggerEvent("pma-voice:radioActive", false)
-		playMicClicks(false)
-		if GetConvarInt('voice_enableRadioAnim', 0) == 1 then
-			StopAnimTask(PlayerPedId(), "random@arrests", "generic_radio_enter", -4.0)
-		end
-		TriggerServerEvent('pma-voice:setTalkingOnRadio', false)
-	end
+    if (radioChannel > 0 or radioEnabled) and radioPressed then
+        radioPressed = false
+        MumbleClearVoiceTargetPlayers(voiceTarget)
+        playerTargets(MumbleIsPlayerTalking(PlayerId()) and callData or {})
+        TriggerEvent("pma-voice:radioActive", false)
+        playMicClicks(false)
+        if GetConvarInt('voice_enableRadioAnim', 0) == 1 then
+            StopAnimTask(PlayerPedId(), "random@arrests", "generic_radio_enter", -4.0)
+        end
+        TriggerServerEvent('pma-voice:setTalkingOnRadio', false)
+    end
 end, false)
 if gameVersion == 'fivem' then
-	RegisterKeyMapping('+radiotalk', 'Talk over Radio', 'keyboard', GetConvar('voice_defaultRadio', 'LMENU'))
+    RegisterKeyMapping('+radiotalk', 'Talk over Radio', 'keyboard', GetConvar('voice_defaultRadio', 'LMENU'))
 end
 
 --- event syncRadio
 --- syncs the players radio, only happens if the radio was set server side.
 ---@param _radioChannel number the radio channel to set the player to.
 function syncRadio(_radioChannel)
-	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
-	logger.info('[radio] radio set serverside update to radio %s', radioChannel)
-	radioChannel = _radioChannel
+    if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
+    logger.info('[radio] radio set serverside update to radio %s', radioChannel)
+    radioChannel = _radioChannel
 end
+
 RegisterNetEvent('pma-voice:clSetPlayerRadio', syncRadio)

--- a/client/utils/Nui.lua
+++ b/client/utils/Nui.lua
@@ -1,11 +1,11 @@
 local uiReady = promise.new()
 function sendUIMessage(message)
-	Citizen.Await(uiReady)
-	SendNUIMessage(message)
+    Citizen.Await(uiReady)
+    SendNUIMessage(message)
 end
 
 RegisterNUICallback("uiReady", function(data, cb)
-	uiReady:resolve(true)
+    uiReady:resolve(true)
 
-	cb('ok')
+    cb('ok')
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ author 'AvarianKnight'
 description 'VOIP built using FiveM\'s built in mumble.'
 
 dependencies {
-   '/onesync',
+    '/onesync',
 }
 
 lua54 'yes'
@@ -13,19 +13,19 @@ lua54 'yes'
 shared_script 'shared.lua'
 
 client_scripts {
-	'client/utils/*',
-	'client/init/proximity.lua',
-	'client/init/init.lua',
-	'client/init/main.lua',
-	'client/init/submix.lua',
-	'client/module/*.lua',
+    'client/utils/*',
+    'client/init/proximity.lua',
+    'client/init/init.lua',
+    'client/init/main.lua',
+    'client/init/submix.lua',
+    'client/module/*.lua',
     'client/*.lua',
     'client/custom_modules/*.lu'
 }
 
 server_scripts {
     'server/**/*.lua',
-	'server/**/*.js',
+    'server/**/*.js',
     'server/custom_modules/*.lua'
 }
 
@@ -39,7 +39,7 @@ files {
 ui_page 'ui/index.html'
 
 provides {
-	'mumble-voip',
+    'mumble-voip',
     'tokovoip',
     'toko-voip',
     'tokovoip_script'
@@ -48,25 +48,25 @@ provides {
 convar_category 'PMA-Voice' {
     "PMA-Voice Configuration Options",
     {
-        { "Use native audio", "$voice_useNativeAudio", "CV_BOOL", "false" },
-	{ "Use 2D audio", "$voice_use2dAudio", "CV_BOOL", "false" },
-	{ "Use sending range only", "$voice_useSendingRangeOnly", "CV_BOOL", "false" },
-	{ "Enable UI", "$voice_enableUi", "CV_INT", "1" },
-	{ "Enable F11 proximity key", "$voice_enableProximityCycle", "CV_INT", "1" },
-	{ "Proximity cycle key", "$voice_defaultCycle", "CV_STRING", "F11" },
-	{ "Voice radio volume", "$voice_defaultRadioVolume", "CV_INT", "30" },
-	{ "Voice call volume", "$voice_defaultCallVolume", "CV_INT", "60" },
-	{ "Enable radios", "$voice_enableRadios", "CV_INT", "1" },
-	{ "Enable calls", "$voice_enableCalls", "CV_INT", "1" },
-	{ "Enable submix", "$voice_enableSubmix", "CV_INT", "1" },
-        { "Enable radio animation", "$voice_enableRadioAnim", "CV_INT", "0" },
-	{ "Radio key", "$voice_defaultRadio", "CV_STRING", "LMENU" },
-	{ "UI refresh rate", "$voice_uiRefreshRate", "CV_INT", "200" },
-	{ "Allow players to set audio intent", "$voice_allowSetIntent", "CV_INT", "1" },
-	{ "External mumble server address", "$voice_externalAddress", "CV_STRING", "" },
-	{ "External mumble server port", "$voice_externalPort", "CV_INT", "0" },
-	{ "Voice debug mode", "$voice_debugMode", "CV_INT", "0" },
-	{ "Disable players being allowed to join", "$voice_externalDisallowJoin", "CV_INT", "0" },
-	{ "Hide server endpoints in logs", "$voice_hideEndpoints", "CV_INT", "1" },
+        { "Use native audio",                      "$voice_useNativeAudio",       "CV_BOOL",   "false" },
+        { "Use 2D audio",                          "$voice_use2dAudio",           "CV_BOOL",   "false" },
+        { "Use sending range only",                "$voice_useSendingRangeOnly",  "CV_BOOL",   "false" },
+        { "Enable UI",                             "$voice_enableUi",             "CV_INT",    "1" },
+        { "Enable F11 proximity key",              "$voice_enableProximityCycle", "CV_INT",    "1" },
+        { "Proximity cycle key",                   "$voice_defaultCycle",         "CV_STRING", "F11" },
+        { "Voice radio volume",                    "$voice_defaultRadioVolume",   "CV_INT",    "30" },
+        { "Voice call volume",                     "$voice_defaultCallVolume",    "CV_INT",    "60" },
+        { "Enable radios",                         "$voice_enableRadios",         "CV_INT",    "1" },
+        { "Enable calls",                          "$voice_enableCalls",          "CV_INT",    "1" },
+        { "Enable submix",                         "$voice_enableSubmix",         "CV_INT",    "1" },
+        { "Enable radio animation",                "$voice_enableRadioAnim",      "CV_INT",    "0" },
+        { "Radio key",                             "$voice_defaultRadio",         "CV_STRING", "LMENU" },
+        { "UI refresh rate",                       "$voice_uiRefreshRate",        "CV_INT",    "200" },
+        { "Allow players to set audio intent",     "$voice_allowSetIntent",       "CV_INT",    "1" },
+        { "External mumble server address",        "$voice_externalAddress",      "CV_STRING", "" },
+        { "External mumble server port",           "$voice_externalPort",         "CV_INT",    "0" },
+        { "Voice debug mode",                      "$voice_debugMode",            "CV_INT",    "0" },
+        { "Disable players being allowed to join", "$voice_externalDisallowJoin", "CV_INT",    "0" },
+        { "Hide server endpoints in logs",         "$voice_hideEndpoints",        "CV_INT",    "1" },
     }
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,11 +20,13 @@ client_scripts {
 	'client/init/submix.lua',
 	'client/module/*.lua',
     'client/*.lua',
+    'client/custom_modules/*.lu'
 }
 
 server_scripts {
     'server/**/*.lua',
-	'server/**/*.js'
+	'server/**/*.js',
+    'server/custom_modules/*.lua'
 }
 
 files {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,7 +20,7 @@ client_scripts {
     'client/init/submix.lua',
     'client/module/*.lua',
     'client/*.lua',
-    'client/custom_modules/*.lu'
+    'client/custom_modules/*.lua'
 }
 
 server_scripts {

--- a/server/custom_modules/.gitignore
+++ b/server/custom_modules/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,122 +3,126 @@ radioData = {}
 callData = {}
 
 function defaultTable(source)
-	handleStateBagInitilization(source)
-	return {
-		radio = 0,
-		call = 0,
-		lastRadio = 0,
-		lastCall = 0
-	}
+    handleStateBagInitilization(source)
+    return {
+        radio = 0,
+        call = 0,
+        lastRadio = 0,
+        lastCall = 0
+    }
 end
 
 function handleStateBagInitilization(source)
-	local plyState = Player(source).state
-	if not plyState.pmaVoiceInit then 
-		plyState:set('radio', GetConvarInt('voice_defaultRadioVolume', 30), true)
-		plyState:set('call', GetConvarInt('voice_defaultCallVolume', 60), true)
-		plyState:set('submix', nil, true)
-		plyState:set('proximity', {}, true)
-		plyState:set('callChannel', 0, true)
-		plyState:set('radioChannel', 0, true)
-		plyState:set('voiceIntent', 'speech', true)
-		-- We want to save voice inits because we'll automatically reinitalize calls and channels
-		plyState:set('pmaVoiceInit', true, false)
-	end
+    local plyState = Player(source).state
+    if not plyState.pmaVoiceInit then
+        plyState:set('radio', GetConvarInt('voice_defaultRadioVolume', 30), true)
+        plyState:set('call', GetConvarInt('voice_defaultCallVolume', 60), true)
+        plyState:set('submix', nil, true)
+        plyState:set('proximity', {}, true)
+        plyState:set('callChannel', 0, true)
+        plyState:set('radioChannel', 0, true)
+        plyState:set('voiceIntent', 'speech', true)
+        -- We want to save voice inits because we'll automatically reinitalize calls and channels
+        plyState:set('pmaVoiceInit', true, false)
+    end
 end
 
 CreateThread(function()
+    local plyTbl = GetPlayers()
+    for i = 1, #plyTbl do
+        local ply = tonumber(plyTbl[i])
+        voiceData[ply] = defaultTable(plyTbl[i])
+    end
 
-	local plyTbl = GetPlayers()
-	for i = 1, #plyTbl do
-		local ply = tonumber(plyTbl[i])
-		voiceData[ply] = defaultTable(plyTbl[i])
-	end
+    Wait(5000)
 
-	Wait(5000)
+    local nativeAudio = GetConvar('voice_useNativeAudio', 'false')
+    local _3dAudio = GetConvar('voice_use3dAudio', 'false')
+    local _2dAudio = GetConvar('voice_use2dAudio', 'false')
+    local sendingRangeOnly = GetConvar('voice_useSendingRangeOnly', 'false')
+    local gameVersion = GetConvar('gamename', 'fivem')
 
-	local nativeAudio = GetConvar('voice_useNativeAudio', 'false')
-	local _3dAudio = GetConvar('voice_use3dAudio', 'false')
-	local _2dAudio = GetConvar('voice_use2dAudio', 'false')
-	local sendingRangeOnly = GetConvar('voice_useSendingRangeOnly', 'false')
-	local gameVersion = GetConvar('gamename', 'fivem')
-
-	-- handle no convars being set (default drag n' drop)
-	if
-		nativeAudio == 'false'
-		and _3dAudio == 'false'
-		and _2dAudio == 'false'
-	then
+    -- handle no convars being set (default drag n' drop)
+    if
+        nativeAudio == 'false'
+        and _3dAudio == 'false'
+        and _2dAudio == 'false'
+    then
         SetConvarReplicated('voice_useNativeAudio', 'true')
         if sendingRangeOnly == 'false' then
             SetConvarReplicated('voice_useSendingRangeOnly', 'true')
-            logger.info('No convars detected for voice mode, defaulting to \'setr voice_useNativeAudio true\' and \'setr voice_useSendingRangeOnly true\'')
+            logger.info(
+            'No convars detected for voice mode, defaulting to \'setr voice_useNativeAudio true\' and \'setr voice_useSendingRangeOnly true\'')
         end
-	elseif sendingRangeOnly == 'false' then
-		logger.warn('It\'s recommended to have \'voice_useSendingRangeOnly\' set to true you can do that with \'setr voice_useSendingRangeOnly true\', this prevents players who directly join the mumble server from broadcasting to players.')
-	end
+    elseif sendingRangeOnly == 'false' then
+        logger.warn(
+        'It\'s recommended to have \'voice_useSendingRangeOnly\' set to true you can do that with \'setr voice_useSendingRangeOnly true\', this prevents players who directly join the mumble server from broadcasting to players.')
+    end
 
-	local radioVolume = GetConvarInt("voice_defaultRadioVolume", 30)
-	local callVolume = GetConvarInt("voice_defaultCallVolume", 60)
+    local radioVolume = GetConvarInt("voice_defaultRadioVolume", 30)
+    local callVolume = GetConvarInt("voice_defaultCallVolume", 60)
 
-	-- When casted to an integer these get set to 0 or 1, so warn on these values that they don't work
-	if
-		radioVolume == 0 or radioVolume == 1 or
-		callVolume == 0 or callVolume == 1
-	then
-		SetConvarReplicated("voice_defaultRadioVolume", 30)
-		SetConvarReplicated("voice_defaultCallVolume", 60)
-		for i = 1, 5 do
-			Wait(5000)
-			logger.warn("`voice_defaultRadioVolume` or `voice_defaultCallVolume` have their value set as a float, this is going to automatically be fixed but please update your convars.")
-		end
-	end
+    -- When casted to an integer these get set to 0 or 1, so warn on these values that they don't work
+    if
+        radioVolume == 0 or radioVolume == 1 or
+        callVolume == 0 or callVolume == 1
+    then
+        SetConvarReplicated("voice_defaultRadioVolume", 30)
+        SetConvarReplicated("voice_defaultCallVolume", 60)
+        for i = 1, 5 do
+            Wait(5000)
+            logger.warn(
+            "`voice_defaultRadioVolume` or `voice_defaultCallVolume` have their value set as a float, this is going to automatically be fixed but please update your convars.")
+        end
+    end
 end)
 
 AddEventHandler('playerJoining', function()
-	if not voiceData[source] then
-		voiceData[source] = defaultTable(source)
-	end
+    if not voiceData[source] then
+        voiceData[source] = defaultTable(source)
+    end
 end)
 
 AddEventHandler("playerDropped", function()
-	local source = source
-	if voiceData[source] then
-		local plyData = voiceData[source]
+    local source = source
+    if voiceData[source] then
+        local plyData = voiceData[source]
 
-		if plyData.radio ~= 0 then
-			removePlayerFromRadio(source, plyData.radio)
-		end
+        if plyData.radio ~= 0 then
+            removePlayerFromRadio(source, plyData.radio)
+        end
 
-		if plyData.call ~= 0 then
-			removePlayerFromCall(source, plyData.call)
-		end
+        if plyData.call ~= 0 then
+            removePlayerFromCall(source, plyData.call)
+        end
 
-		voiceData[source] = nil
-	end
+        voiceData[source] = nil
+    end
 end)
 
 if GetConvarInt('voice_externalDisallowJoin', 0) == 1 then
-	AddEventHandler('playerConnecting', function(_, _, deferral)
-		deferral.defer()
-		Wait(0)
-		deferral.done('This server is not accepting connections.')
-	end)
+    AddEventHandler('playerConnecting', function(_, _, deferral)
+        deferral.defer()
+        Wait(0)
+        deferral.done('This server is not accepting connections.')
+    end)
 end
 
 -- only meant for internal use so no documentation
 function isValidPlayer(source)
-	return voiceData[source]
+    return voiceData[source]
 end
+
 exports('isValidPlayer', isValidPlayer)
 
 function getPlayersInRadioChannel(channel)
-	local returnChannel = radioData[channel]
-	if returnChannel then
-		return returnChannel
-	end
-	-- channel doesnt exist
-	return {}
+    local returnChannel = radioData[channel]
+    if returnChannel then
+        return returnChannel
+    end
+    -- channel doesnt exist
+    return {}
 end
+
 exports('getPlayersInRadioChannel', getPlayersInRadioChannel)
 exports('GetPlayersInRadioChannel', getPlayersInRadioChannel)

--- a/server/module/phone.lua
+++ b/server/module/phone.lua
@@ -14,7 +14,7 @@ function removePlayerFromCall(source, callChannel)
 end
 
 --- adds a player to a call
----@param source number the player to add to the call 
+---@param source number the player to add to the call
 ---@param callChannel number the call channel to add them to
 function addPlayerToCall(source, callChannel)
     logger.verbose('[call] Added %s to call %s', source, callChannel)
@@ -37,24 +37,25 @@ end
 ---@param source number the player to set the call off
 ---@param _callChannel number the channel to set the player to (or 0 to remove them from any call channel)
 function setPlayerCall(source, _callChannel)
-	if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
+    if GetConvarInt('voice_enableCalls', 1) ~= 1 then return end
     voiceData[source] = voiceData[source] or defaultTable(source)
     local isResource = GetInvokingResource()
     local plyVoice = voiceData[source]
     local callChannel = tonumber(_callChannel)
     if not callChannel then
-		-- only full error if its sent from another server-side resource
-		if isResource then
-			error(("'callChannel' expected 'number', got: %s"):format(type(_callChannel)))
-		else
-			return logger.warn("%s sent a invalid call, 'callChannel' expected 'number', got: %s", source,type(_callChannel))
-		end
-	end
-	if isResource then
-		-- got set in a export, need to update the client to tell them that their call
-		-- changed
-		TriggerClientEvent('pma-voice:clSetPlayerCall', source, callChannel)
-	end
+        -- only full error if its sent from another server-side resource
+        if isResource then
+            error(("'callChannel' expected 'number', got: %s"):format(type(_callChannel)))
+        else
+            return logger.warn("%s sent a invalid call, 'callChannel' expected 'number', got: %s", source,
+            type(_callChannel))
+        end
+    end
+    if isResource then
+        -- got set in a export, need to update the client to tell them that their call
+        -- changed
+        TriggerClientEvent('pma-voice:clSetPlayerCall', source, callChannel)
+    end
 
     Player(source).state.callChannel = callChannel
 
@@ -67,6 +68,7 @@ function setPlayerCall(source, _callChannel)
         addPlayerToCall(source, callChannel)
     end
 end
+
 exports('setPlayerCall', setPlayerCall)
 
 RegisterNetEvent('pma-voice:setPlayerCall', function(callChannel)

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -5,81 +5,84 @@ local radioChecks = {}
 --- @param radioChannel number the channel they're trying to join
 --- @return boolean if the user can join the channel
 function canJoinChannel(source, radioChannel)
-	if radioChecks[radioChannel] then
-		return radioChecks[radioChannel](source)
-	end
-	return true
+    if radioChecks[radioChannel] then
+        return radioChecks[radioChannel](source)
+    end
+    return true
 end
 
 --- adds a check to the channel, function is expected to return a boolean of true or false
 ---@param channel number the channel to add a check to
 ---@param cb function the function to execute the check on
 function addChannelCheck(channel, cb)
-	local channelType = type(channel)
-	local cbType = type(cb)
-	if channelType ~= "number" then
-		error(("'channel' expected 'number' got '%s'"):format(channelType))
-	end
-	if cbType ~= 'table' or not cb.__cfx_functionReference then
-		error(("'cb' expected 'function' got '%s'"):format(cbType))
-	end
-	radioChecks[channel] = cb
-	logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
+    local channelType = type(channel)
+    local cbType = type(cb)
+    if channelType ~= "number" then
+        error(("'channel' expected 'number' got '%s'"):format(channelType))
+    end
+    if cbType ~= 'table' or not cb.__cfx_functionReference then
+        error(("'cb' expected 'function' got '%s'"):format(cbType))
+    end
+    radioChecks[channel] = cb
+    logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
 end
+
 exports('addChannelCheck', addChannelCheck)
 
 local function radioNameGetter_orig(source)
-	return GetPlayerName(source)
+    return GetPlayerName(source)
 end
 local radioNameGetter = radioNameGetter_orig
 
 --- adds a check to the channel, function is expected to return a boolean of true or false
 ---@param cb function the function to execute the check on
 function overrideRadioNameGetter(channel, cb)
-	local cbType = type(cb)
-	if cbType == 'table' and not cb.__cfx_functionReference then
-		error(("'cb' expected 'function' got '%s'"):format(cbType))
-	end
-	radioNameGetter = cb
-	logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
+    local cbType = type(cb)
+    if cbType == 'table' and not cb.__cfx_functionReference then
+        error(("'cb' expected 'function' got '%s'"):format(cbType))
+    end
+    radioNameGetter = cb
+    logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
 end
+
 exports('overrideRadioNameGetter', overrideRadioNameGetter)
 
 --- adds a player to the specified radion channel
 ---@param source number the player to add to the channel
 ---@param radioChannel number the channel to set them to
 function addPlayerToRadio(source, radioChannel)
-	if not canJoinChannel(source, radioChannel) then
-		-- remove the player from the radio client side
-		return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source)
-	end
-	logger.verbose('[radio] Added %s to radio %s', source, radioChannel)
+    if not canJoinChannel(source, radioChannel) then
+        -- remove the player from the radio client side
+        return TriggerClientEvent('pma-voice:removePlayerFromRadio', source, source)
+    end
+    logger.verbose('[radio] Added %s to radio %s', source, radioChannel)
 
-	-- check if the channel exists, if it does set the varaible to it
-	-- if not create it (basically if not radiodata make radiodata)
-	radioData[radioChannel] = radioData[radioChannel] or {}
-	local plyName = radioNameGetter(source)
-	for player, _ in pairs(radioData[radioChannel]) do
-		TriggerClientEvent('pma-voice:addPlayerToRadio', player, source, plyName)
-	end
-	voiceData[source] = voiceData[source] or defaultTable(source)
-	voiceData[source].radio = radioChannel
-	radioData[radioChannel][source] = false
-	TriggerClientEvent('pma-voice:syncRadioData', source, radioData[radioChannel], GetConvarInt("voice_syncPlayerNames", 0) == 1 and plyName)
+    -- check if the channel exists, if it does set the varaible to it
+    -- if not create it (basically if not radiodata make radiodata)
+    radioData[radioChannel] = radioData[radioChannel] or {}
+    local plyName = radioNameGetter(source)
+    for player, _ in pairs(radioData[radioChannel]) do
+        TriggerClientEvent('pma-voice:addPlayerToRadio', player, source, plyName)
+    end
+    voiceData[source] = voiceData[source] or defaultTable(source)
+    voiceData[source].radio = radioChannel
+    radioData[radioChannel][source] = false
+    TriggerClientEvent('pma-voice:syncRadioData', source, radioData[radioChannel],
+    GetConvarInt("voice_syncPlayerNames", 0) == 1 and plyName)
 end
 
 --- removes a player from the specified channel
 ---@param source number the player to remove
 ---@param radioChannel number the current channel to remove them from
 function removePlayerFromRadio(source, radioChannel)
-	logger.verbose('[radio] Removed %s from radio %s', source, radioChannel)
-	radioData[radioChannel] = radioData[radioChannel] or {}
-	for player, _ in pairs(radioData[radioChannel]) do
-		TriggerClientEvent('pma-voice:removePlayerFromRadio', player, source)
-	end
-	radioData[radioChannel][source] = nil
-	voiceData[source] = voiceData[source] or defaultTable(source)
-	voiceData[source].radio = 0
+    logger.verbose('[radio] Removed %s from radio %s', source, radioChannel)
+    radioData[radioChannel] = radioData[radioChannel] or {}
+    for player, _ in pairs(radioData[radioChannel]) do
+        TriggerClientEvent('pma-voice:removePlayerFromRadio', player, source)
+    end
+    radioData[radioChannel][source] = nil
+    voiceData[source] = voiceData[source] or defaultTable(source)
+    voiceData[source].radio = 0
 end
 
 -- TODO: Implement this in a way that allows players to be on multiple channels
@@ -87,79 +90,84 @@ end
 ---@param source number the player to set the channel of
 ---@param _radioChannel number the radio channel to set them to (or 0 to remove them from radios)
 function setPlayerRadio(source, _radioChannel)
-	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
-	voiceData[source] = voiceData[source] or defaultTable(source)
-	local isResource = GetInvokingResource()
-	local plyVoice = voiceData[source]
-	local radioChannel = tonumber(_radioChannel)
-	if not radioChannel then
-		-- only full error if its sent from another server-side resource
-		if isResource then
-			error(("'radioChannel' expected 'number', got: %s"):format(type(_radioChannel))) 
-		else
-			return logger.warn("%s sent a invalid radio, 'radioChannel' expected 'number', got: %s", source,type(_radioChannel))
-		end
-	end
-	if isResource then
-		-- got set in a export, need to update the client to tell them that their radio
-		-- changed
-		TriggerClientEvent('pma-voice:clSetPlayerRadio', source, radioChannel)
-	end
-	Player(source).state.radioChannel = radioChannel
-	if radioChannel ~= 0 and plyVoice.radio == 0 then
-		addPlayerToRadio(source, radioChannel)
-	elseif radioChannel == 0 then
-		removePlayerFromRadio(source, plyVoice.radio)
-	elseif plyVoice.radio > 0 then
-		removePlayerFromRadio(source, plyVoice.radio)
-		addPlayerToRadio(source, radioChannel)
-	end
+    if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
+    voiceData[source] = voiceData[source] or defaultTable(source)
+    local isResource = GetInvokingResource()
+    local plyVoice = voiceData[source]
+    local radioChannel = tonumber(_radioChannel)
+    if not radioChannel then
+        -- only full error if its sent from another server-side resource
+        if isResource then
+            error(("'radioChannel' expected 'number', got: %s"):format(type(_radioChannel)))
+        else
+            return logger.warn("%s sent a invalid radio, 'radioChannel' expected 'number', got: %s", source,
+            type(_radioChannel))
+        end
+    end
+    if isResource then
+        -- got set in a export, need to update the client to tell them that their radio
+        -- changed
+        TriggerClientEvent('pma-voice:clSetPlayerRadio', source, radioChannel)
+    end
+    Player(source).state.radioChannel = radioChannel
+    if radioChannel ~= 0 and plyVoice.radio == 0 then
+        addPlayerToRadio(source, radioChannel)
+    elseif radioChannel == 0 then
+        removePlayerFromRadio(source, plyVoice.radio)
+    elseif plyVoice.radio > 0 then
+        removePlayerFromRadio(source, plyVoice.radio)
+        addPlayerToRadio(source, radioChannel)
+    end
 end
+
 exports('setPlayerRadio', setPlayerRadio)
 
 RegisterNetEvent('pma-voice:setPlayerRadio', function(radioChannel)
-	setPlayerRadio(source, radioChannel)
+    setPlayerRadio(source, radioChannel)
 end)
 
 --- syncs the player talking across all radio members
 ---@param talking boolean sets if the palyer is talking.
 function setTalkingOnRadio(talking)
-	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
-	voiceData[source] = voiceData[source] or defaultTable(source)
-	local plyVoice = voiceData[source]
-	local radioTbl = radioData[plyVoice.radio]
-	if radioTbl then
-		radioTbl[source] = talking
-		logger.verbose('[radio] Set %s to talking: %s on radio %s',source, talking, plyVoice.radio)
-		for player, _ in pairs(radioTbl) do
-			if player ~= source then
-				TriggerClientEvent('pma-voice:setTalkingOnRadio', player, source, talking)
-				logger.verbose('[radio] Sync %s to let them know %s is %s',player, source, talking and 'talking' or 'not talking')
-			end
-		end
-	end
+    if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
+    voiceData[source] = voiceData[source] or defaultTable(source)
+    local plyVoice = voiceData[source]
+    local radioTbl = radioData[plyVoice.radio]
+    if radioTbl then
+        radioTbl[source] = talking
+        logger.verbose('[radio] Set %s to talking: %s on radio %s', source, talking, plyVoice.radio)
+        for player, _ in pairs(radioTbl) do
+            if player ~= source then
+                TriggerClientEvent('pma-voice:setTalkingOnRadio', player, source, talking)
+                logger.verbose('[radio] Sync %s to let them know %s is %s', player, source,
+                talking and 'talking' or 'not talking')
+            end
+        end
+    end
 end
+
 RegisterNetEvent('pma-voice:setTalkingOnRadio', setTalkingOnRadio)
 
 AddEventHandler("onResourceStop", function(resource)
-	for channel, cfxFunctionRef in pairs(radioChecks) do
-		local functionRef = cfxFunctionRef.__cfx_functionReference
-		local functionResource = string.match(functionRef, resource)
-		if functionResource then
-			radioChecks[channel] = nil
-			logger.warn('Channel %s had its radio check removed because the resource that gave the checks stopped', channel)
-		end
-	end
+    for channel, cfxFunctionRef in pairs(radioChecks) do
+        local functionRef = cfxFunctionRef.__cfx_functionReference
+        local functionResource = string.match(functionRef, resource)
+        if functionResource then
+            radioChecks[channel] = nil
+            logger.warn('Channel %s had its radio check removed because the resource that gave the checks stopped',
+            channel)
+        end
+    end
 
-	if type(radioNameGetter) == "table" then
-		local radioRef = radioNameGetter.__cfx_functionReference
-		if radioRef then
-			local isResource = string.match(radioRef, resource)
-			if isResource then
-				radioNameGetter = radioNameGetter_orig
-				logger.warn('Radio name getter is resetting to default because the resource that gave the cb got turned off')
-			end
-		end
-	end
-
+    if type(radioNameGetter) == "table" then
+        local radioRef = radioNameGetter.__cfx_functionReference
+        if radioRef then
+            local isResource = string.match(radioRef, resource)
+            if isResource then
+                radioNameGetter = radioNameGetter_orig
+                logger.warn(
+                'Radio name getter is resetting to default because the resource that gave the cb got turned off')
+            end
+        end
+    end
 end)

--- a/server/mute.js
+++ b/server/mute.js
@@ -2,25 +2,25 @@ let mutedPlayers = {}
 // this is implemented in JS due to Lua's lack of a ClearTimeout
 // muteply instead of mute because mute conflicts with rp-radio
 RegisterCommand('muteply', (source, args) => {
-	const mutePly = parseInt(args[0])
-	const duration = parseInt(args[1]) || 900
-	if (mutePly && exports['pma-voice'].isValidPlayer(mutePly)) {
-		const isMuted = !MumbleIsPlayerMuted(mutePly);
-		Player(mutePly).state.muted = isMuted;
-		MumbleSetPlayerMuted(mutePly, isMuted);
-		emit('pma-voice:playerMuted', mutePly, source, isMuted, duration);
-		// since this is a toggle, if theres a mutedPlayers entry it can be assumed
-		// that they're currently muted, so we'll clear the timeout and unmute
-		if (mutedPlayers[mutePly]) {
-			clearTimeout(mutedPlayers[mutePly]);
-			MumbleSetPlayerMuted(mutePly, isMuted)
-			Player(mutePly).state.muted = isMuted;
-			return;
-		}
-		mutedPlayers[mutePly] = setTimeout(() => {
-			MumbleSetPlayerMuted(mutePly, !isMuted)
-			Player(mutePly).state.muted = !isMuted;
-			delete mutedPlayers[mutePly]
-		}, duration * 1000)
-	}
+    const mutePly = parseInt(args[0])
+    const duration = parseInt(args[1]) || 900
+    if (mutePly && exports['pma-voice'].isValidPlayer(mutePly)) {
+        const isMuted = !MumbleIsPlayerMuted(mutePly);
+        Player(mutePly).state.muted = isMuted;
+        MumbleSetPlayerMuted(mutePly, isMuted);
+        emit('pma-voice:playerMuted', mutePly, source, isMuted, duration);
+        // since this is a toggle, if theres a mutedPlayers entry it can be assumed
+        // that they're currently muted, so we'll clear the timeout and unmute
+        if (mutedPlayers[mutePly]) {
+            clearTimeout(mutedPlayers[mutePly]);
+            MumbleSetPlayerMuted(mutePly, isMuted)
+            Player(mutePly).state.muted = isMuted;
+            return;
+        }
+        mutedPlayers[mutePly] = setTimeout(() => {
+            MumbleSetPlayerMuted(mutePly, !isMuted)
+            Player(mutePly).state.muted = !isMuted;
+            delete mutedPlayers[mutePly]
+        }, duration * 1000)
+    }
 }, true)

--- a/shared.lua
+++ b/shared.lua
@@ -48,13 +48,13 @@ if GetConvar('voice_useNativeAudio', 'false') == 'true' then
     -- native audio distance seems to be larger then regular gta units
     Cfg.voiceModes = {
         { 1.5, "Whisper" }, -- Whisper speech distance in gta distance units
-        { 3.0, "Normal" }, -- Normal speech distance in gta distance units
+        { 3.0, "Normal" },  -- Normal speech distance in gta distance units
         { 6.0, "Shouting" } -- Shout speech distance in gta distance units
     }
 else
     Cfg.voiceModes = {
         { 3.0,  "Whisper" }, -- Whisper speech distance in gta distance units
-        { 7.0,  "Normal" }, -- Normal speech distance in gta distance units
+        { 7.0,  "Normal" },  -- Normal speech distance in gta distance units
         { 15.0, "Shouting" } -- Shout speech distance in gta distance units
     }
 end


### PR DESCRIPTION
This simply adds `server/custom_modules` and `client/custom_modules` to the fxmanifest to load.

## It should still be noted that using pma-voice internals have no guaranteed stability so custom_modules could break on pma-voice updates

This would allow stuff like https://github.com/AvarianKnight/pma-voice/pull/395 and https://github.com/AvarianKnight/pma-voice/pull/402 to be loaded and use internal pma-voice functions

TODO: Maybe a repo that links to custom modules and people can PR their own additions (or link their repo?)