### PR TITLE
Better Mumble Channel Mapping

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -3,14 +3,14 @@ function handleInitialState()
 	MumbleSetTalkerProximity(voiceModeData[1] + 0.0)
 	MumbleClearVoiceTarget(voiceTarget)
 	MumbleSetVoiceTarget(voiceTarget)
-	MumbleSetVoiceChannel(playerServerId)
+	MumbleSetVoiceChannel(LocalPlayer.state.assignedChannel)
 
-	while MumbleGetVoiceChannelFromServerId(playerServerId) ~= playerServerId do
+	while MumbleGetVoiceChannelFromServerId(playerServerId) ~= LocalPlayer.state.assignedChannel do
 		Wait(250)
-		MumbleSetVoiceChannel(playerServerId)
+		MumbleSetVoiceChannel(LocalPlayer.state.assignedChannel)
 	end
 
-	MumbleAddVoiceTargetChannel(voiceTarget, playerServerId)
+	MumbleAddVoiceTargetChannel(voiceTarget, LocalPlayer.state.assignedChannel)
 
 	addNearbyPlayers()
 end


### PR DESCRIPTION
This fixes an issue where if you have an external mumble server (not FXServer) and server IDs go over the max amount of channels that exist, it results in subsequent connections not being assigned a channel.

TDLR of this change is that each player is now assigned to whatever the first free mumble channel is instead of their server id, the current max for the free channel loop is `GetConvarInt('sv_maxclients', 32) + 10` for a bit of leniency.