### PR TITLE
Fixed different script name causing /muteply error

### DIFF
--- a/server/mute.js
+++ b/server/mute.js
@@ -4,7 +4,7 @@ let mutedPlayers = {}
 RegisterCommand('muteply', (source, args) => {
 	const mutePly = parseInt(args[0])
 	const duration = parseInt(args[1]) || 900
-	if (mutePly && exports['pma-voice'].isValidPlayer(mutePly)) {
+	if (mutePly && exports[GetCurrentResourceName()].isValidPlayer(mutePly)) {
 		const isMuted = !MumbleIsPlayerMuted(mutePly);
 		Player(mutePly).state.muted = isMuted;
 		MumbleSetPlayerMuted(mutePly, isMuted);


### PR DESCRIPTION
- Fixed renaming the script folder causing /muteply export to fail.