### PR TITLE
Add Secondary Radio Channel and ATC

### DIFF
--- a/client/init/init.lua
+++ b/client/init/init.lua
@@ -32,12 +32,18 @@ AddEventHandler('onClientResourceStart', function(resource)
 
 	local radioChannel = LocalPlayer.state.radioChannel or 0
 	local callChannel = LocalPlayer.state.callChannel or 0
-
+	local secondaryRadioChannel = LocalPlayer.state.secondaryRadioChannel or 0
+	local ATCRadioChannel = LocalPlayer.state.ATCRadioChannel or 0
 	-- Reinitialize channels if they're set.
 	if radioChannel ~= 0 then
-		setRadioChannel(radioChannel)
+		setRadioChannel(radioChannel, "radio")
 	end
-
+	if secondaryRadioChannel ~= 0 then
+		setRadioChannel(secondaryRadioChannel, "secradio")
+	end
+	if ATCRadioChannel ~= 0 then
+		setRadioChannel(ATCRadioChannel, "atcradio")
+	end
 	if callChannel ~= 0 then
 		setCallChannel(callChannel)
 	end

--- a/server/main.lua
+++ b/server/main.lua
@@ -19,7 +19,9 @@ function defaultTable(source)
 		radio = 0,
 		call = 0,
 		lastRadio = 0,
-		lastCall = 0
+		lastCall = 0,
+		secradio = 0,
+		atcradio = 0
 	}
 end
 
@@ -27,11 +29,15 @@ function handleStateBagInitilization(source)
 	local plyState = Player(source).state
 	if not plyState.pmaVoiceInit then
 		plyState:set('radio', GetConvarInt('voice_defaultRadioVolume', 30), true)
+		plyState:set('secradio', GetConvarInt('voice_defaultRadioVolume', 30), true)
+		plyState:set('atcradio', GetConvarInt('voice_defaultRadioVolume', 30), true)
 		plyState:set('call', GetConvarInt('voice_defaultCallVolume', 60), true)
 		plyState:set('submix', nil, true)
 		plyState:set('proximity', {}, true)
 		plyState:set('callChannel', 0, true)
 		plyState:set('radioChannel', 0, true)
+		plyState:set('secondaryRadioChannel', 0, true)
+		plyState:set('ATCRadioChannel', 0, true)
 		plyState:set('voiceIntent', 'speech', true)
 		-- We want to save voice inits because we'll automatically reinitalize calls and channels
 		plyState:set('pmaVoiceInit', true, false)
@@ -113,7 +119,13 @@ AddEventHandler("playerDropped", function()
 		local plyData = voiceData[source]
 
 		if plyData.radio ~= 0 then
-			removePlayerFromRadio(source, plyData.radio)
+			removePlayerFromRadio(source, plyData.radio, 'radio')
+		end
+		if plyData.secradio ~= 0 then
+			removePlayerFromRadio(source, plyData.secradio, 'secradio')
+		end
+		if plyData.atcradio ~= 0 then
+			removePlayerFromRadio(source, plyData.atcradio, 'atcradio')
 		end
 
 		if plyData.call ~= 0 then

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -1,30 +1,19 @@
 local radioChecks = {}
 
+
+
+
 --- checks if the player can join the channel specified
 --- @param source number the source of the player
 --- @param radioChannel number the channel they're trying to join
 --- @return boolean if the user can join the channel
 function canJoinChannel(source, radioChannel)
+	
 	if radioChecks[radioChannel] then
 		return radioChecks[radioChannel](source)
 	end
 	return true
 end
-
-
-local function dump(o)
-    if type(o) == 'table' then
-        local s = '{ '
-        for k, v in pairs(o) do
-            if type(k) ~= 'number' then k = '"' .. k .. '"' end
-            s = s .. '[' .. k .. '] = ' .. dump(v) .. ','
-        end
-        return s .. '} '
-    else
-        return tostring(o)
-    end
-end
-
 
 --- adds a check to the channel, function is expected to return a boolean of true or false
 ---@param channel number the channel to add a check to
@@ -67,11 +56,8 @@ exports('overrideRadioNameGetter', overrideRadioNameGetter)
 ---@param radioChannel number the channel to set them to
 ---@return boolean wasAdded if the player was successfuly added to the radio channel, or if it failed.
 function addPlayerToRadio(source, radioChannel, freq)
-	print("AddPlayerToRadio")
-	print (dump(source))
-	print(dump(radioChannel))
-	print(dump(freq))
 	
+
 	if not canJoinChannel(source, radioChannel) then
 		-- remove the player from the radio client side
 		TriggerClientEvent("pma-voice:radioChangeRejected", source)
@@ -116,10 +102,13 @@ end
 ---@param _radioChannel number the radio channel to set them to (or 0 to remove them from radios)
 ---@param freq string radio, secradio,atcradio
 function setPlayerRadio(source, _radioChannel, freq)
-	print("ServerFunction:setPlayerRadio")
-	print(dump(_radioChannel))
-	print(dump(freq))
 	
+	
+	if freq == nil then
+		freq = "radio"
+	end
+	
+
 	
 	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
 	voiceData[source] = voiceData[source] or defaultTable(source)
@@ -144,21 +133,19 @@ function setPlayerRadio(source, _radioChannel, freq)
 		if plyVoice[freq] > 0 then
 			removePlayerFromRadio(source, plyVoice[freq], freq)
 		end
-		local wasAdded = addPlayerToRadio(source, radioChannel,freq)
+		local wasAdded = addPlayerToRadio(source, radioChannel, freq)
 		Player(source).state.radioChannel = wasAdded and radioChannel or 0
 	elseif radioChannel == 0 then
-		removePlayerFromRadio(source, plyVoice[freq],freq)
+		removePlayerFromRadio(source, plyVoice[freq], freq)
 		Player(source).state.radioChannel = 0
 	end
 end
 
 exports('setPlayerRadio', setPlayerRadio)
 
-RegisterNetEvent('pma-voice:setPlayerRadio', function(radioChannel,freq)
-	print("ServerEvent:pma-voice:setPlayerRadio")
-	print(dump(radioChannel))
-	print(dump(freq))
+RegisterNetEvent('pma-voice:setPlayerRadio', function(radioChannel, freq)
 	
+
 	setPlayerRadio(source, radioChannel, freq)
 end)
 
@@ -168,11 +155,9 @@ end)
 function setTalkingOnRadio(talking, freq)
 	if GetConvarInt('voice_enableRadios', 1) ~= 1 then return end
 	voiceData[source] = voiceData[source] or defaultTable(source)
-	print("VoiceData")
-	print(dump(voiceData))
+	
 	local plyVoice = voiceData[source]
-	print("Radio Data")
-	print(dump(radioData))
+	
 	local radioTbl = radioData[plyVoice[freq]]
 	if radioTbl then
 		radioTbl[source] = talking


### PR DESCRIPTION
Modified Radio submodules in order to provide a dual channel Radio

Accessible by using Export with extra Freq variable

Set Primary with
`exports["pma-voice"]:setRadioChannel(channel, "radio")`

Set Secondary with 
`exports["pma-voice"]:setRadioChannel(channel, "secradio")`

Set ATC with 
`exports["pma-voice"]:setRadioChannel(channel, "secradio")`

Convar to enable 

`setr voice_enableSecRadio 1`

Convar to enable ATC

`setr voice_enableATCRadio 1`


Tested against a modified mm_radio for Dual Freq and unmodified qb-radio to ensure changes were non breaking

With some minor modification was able to use qb-radio for civilians and mm_radio for Govt

