### PR TITLE
feat: add export to check if a player is in any radio channel

### DIFF
--- a/client/module/radio.lua
+++ b/client/module/radio.lua
@@ -291,3 +291,6 @@ local function removeRadioDisableBit(bit)
 end
 exports("removeRadioDisableBit", removeRadioDisableBit)
 
+exports("isPlayerInAnyRadio", function()
+    return radioChannel > 0
+end)


### PR DESCRIPTION
While working on my HUD recently, I needed to check if a player was in any radio channel. Since this wasn't possible, I added a new export:
```lua
exports("isPlayerInAnyRadio", function()
    return radioChannel > 0
end)
```

This export allows scripts to determine if a player is in any radio channel (radioChannel > 0). It’s a simple and useful addition for developers needing this functionality.