### PR TITLE
Added version number in fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,4 +1,5 @@
 game 'common'
+version '7.0.1'
 
 fx_version 'cerulean'
 author 'AvarianKnight'


### PR DESCRIPTION
A version number has been added. This allows different scripts to check the script's version number or users can find out which version they are using from the fxmanifest file