### PR TITLE
feat: convar for disabling specific submix (call/radio), while keeping the other

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ If you previously used `voice_enablePhones` you will instead need to use `voice_
 If you were previously using the state bag getter `Player(source).state.phone` you will instead need to use `Player(source).state.call`
 
 # pma-voice
+
 A voice system designed around the use of FiveM/RedM internal mumble server.
 
 ## Support
@@ -31,12 +32,12 @@ You only need to add the convar **if** you're changing the value.
 
 All of the configs here are set using `setr [voice_configOption] [boolean]`
 
-| ConVar                     | Default | Description                                                   | Parameter(s) |
-|----------------------------|---------|---------------------------------------------------------------|--------------|
-| voice_useNativeAudio       |  false  | Uses the games native audio, will add 3d sound, echo, reverb, and more. **Required for submixs**   | boolean      |
-| voice_use2dAudio           |  false  | Uses 2d audio, will result in same volume sound no matter where they're at until they leave proximity. | boolean
-| voice_use3dAudio           |  false  | Uses 3d audio | boolean |
-| voice_useSendingRangeOnly  |  false  | Only allows you to hear people within your hear/send range, prevents people from connecting to your mumble server and trolling. | boolean      |
+| ConVar                    | Default | Description                                                                                                                     | Parameter(s) |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| voice_useNativeAudio      | false   | Uses the games native audio, will add 3d sound, echo, reverb, and more. **Required for submixs**                                | boolean      |
+| voice_use2dAudio          | false   | Uses 2d audio, will result in same volume sound no matter where they're at until they leave proximity.                          | boolean      |
+| voice_use3dAudio          | false   | Uses 3d audio                                                                                                                   | boolean      |
+| voice_useSendingRangeOnly | false   | Only allows you to hear people within your hear/send range, prevents people from connecting to your mumble server and trolling. | boolean      |
 
 # Config
 
@@ -52,46 +53,45 @@ All of the configs here are set using `setr [voice_configOption] [int]` OR `setr
 
 ### General Voice Settings
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_enableUi               |    1    | Enables the built in user interface                            | int          |
-| voice_enableProximityCycle   |    1    | Enables the usage of the F11 proximity key, if disabled players are stuck on the first proximity  | int          |
-| voice_defaultCycle           |   F11   | The default key to cycle the players proximity. You can find a list of valid keys [in the Cfx docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/)                | string       |
-| voice_defaultRadioVolume          |   30   | The default volume to set the radio to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_defaultCallVolume          |   60   | The default volume to set the call to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_onClickVolume          |   10   | The default volume to set the radio turn on mic click's to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_offClickVolume          |   3   | The default volume to set the radio turn off mic click's to (has to be between 1 and 100) *NOTE: Only new joins will have the new value, players that already joined will not.* | float       |
-| voice_defaultVoiceMode  |  2      | Default proximity voice value when player joins server. (Voice Modes; 1:Whisper, 2:Normal, 3:Shouting) | int      |
+| ConVar                     | Default | Description                                                                                                                                                                           | Parameter(s) |
+| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| voice_enableUi             | 1       | Enables the built in user interface                                                                                                                                                   | int          |
+| voice_enableProximityCycle | 1       | Enables the usage of the F11 proximity key, if disabled players are stuck on the first proximity                                                                                      | int          |
+| voice_defaultCycle         | F11     | The default key to cycle the players proximity. You can find a list of valid keys [in the Cfx docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/) | string       |
+| voice_defaultRadioVolume   | 30      | The default volume to set the radio to (has to be between 1 and 100) _NOTE: Only new joins will have the new value, players that already joined will not._                            | float        |
+| voice_defaultCallVolume    | 60      | The default volume to set the call to (has to be between 1 and 100) _NOTE: Only new joins will have the new value, players that already joined will not._                             | float        |
+| voice_onClickVolume        | 10      | The default volume to set the radio turn on mic click's to (has to be between 1 and 100) _NOTE: Only new joins will have the new value, players that already joined will not._        | float        |
+| voice_offClickVolume       | 3       | The default volume to set the radio turn off mic click's to (has to be between 1 and 100) _NOTE: Only new joins will have the new value, players that already joined will not._       | float        |
+| voice_defaultVoiceMode     | 2       | Default proximity voice value when player joins server. (Voice Modes; 1:Whisper, 2:Normal, 3:Shouting)                                                                                | int          |
 
 ### Call & Radio
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_enableRadios           |    1    | Enables the radio sub-modules                                 | int          |
-| voice_enableCalls           |    1    | Enables the call sub-modules                                 | int          |
-| voice_enableSubmix      |    1    | Enables the submix which adds a radio/call style submix to their voice **NOTE: Submixs require native audio** | int          |
-| voice_disableRadioSubmix      |    0    | Disables only the radio submix, 1 = true = disabled. `voice_enableSubmix` has priority over this. | int          |
-| voice_disableCallSubmix      |    0    | Disables only the call submix, 1 = true = disabled. `voice_enableSubmix` has priority over this. | int          |
-| voice_enableRadioAnim        |   1     | Enables (grab shoulder mic) animation while talking on the radio.          | int          |
-| voice_defaultRadio           |   LMENU  | The default key to use the radio. You can find a list of valid keys [in the FiveM docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/)                             | string       |
+| ConVar                   | Default | Description                                                                                                                                                               | Parameter(s) |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| voice_enableRadios       | 1       | Enables the radio sub-modules                                                                                                                                             | int          |
+| voice_enableCalls        | 1       | Enables the call sub-modules                                                                                                                                              | int          |
+| voice_enableSubmix       | 1       | Enables the submix which adds a radio/call style submix to their voice **NOTE: Submixs require native audio**                                                             | int          |
+| voice_disableRadioSubmix | 0       | Disables only the radio submix, 1 = true = disabled. `voice_enableSubmix` has priority over this.                                                                         | int          |
+| voice_disableCallSubmix  | 0       | Disables only the call submix, 1 = true = disabled. `voice_enableSubmix` has priority over this.                                                                          | int          |
+| voice_enableRadioAnim    | 1       | Enables (grab shoulder mic) animation while talking on the radio.                                                                                                         | int          |
+| voice_defaultRadio       | LMENU   | The default key to use the radio. You can find a list of valid keys [in the FiveM docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/) | string       |
 
 ### Sync
 
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_refreshRate   |   200    | How often the UI/Proximity is refreshed | int     |
+| ConVar            | Default | Description                             | Parameter(s) |
+| ----------------- | ------- | --------------------------------------- | ------------ |
+| voice_refreshRate | 200     | How often the UI/Proximity is refreshed | int          |
 
 ### External Server & Misc.
-| ConVar                  | Default | Description                                                        | Parameter(s) |
-|-------------------------|---------|--------------------------------------------------------------------|--------------|
-| voice_allowSetIntent         |   1  | Whether or not to allow players to set their audio intents (you can see more [here](https://docs.fivem.net/natives/?_0x6383526B))  | int       |
-| voice_externalAddress        |   none  | The external address to use to connect to the mumble server   | string       |
-| voice_externalPort           |   0     | The external port to use                                      | int          |
-| voice_debugMode              |   0     | 1 for basic logs, 4 for verbose logs                          | int          |
-| voice_externalDisallowJoin   |   0     | Disables players being allowed to join the server, should only be used if you're using a FXServer as a external mumble server. | int          |
-| voice_hideEndpoints     | 1   | Hides the mumble address in logs *NOTE: You should only care to hide this for a external server.* | int        |
 
-
+| ConVar                     | Default | Description                                                                                                                       | Parameter(s) |
+| -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| voice_allowSetIntent       | 1       | Whether or not to allow players to set their audio intents (you can see more [here](https://docs.fivem.net/natives/?_0x6383526B)) | int          |
+| voice_externalAddress      | none    | The external address to use to connect to the mumble server                                                                       | string       |
+| voice_externalPort         | 0       | The external port to use                                                                                                          | int          |
+| voice_debugMode            | 0       | 1 for basic logs, 4 for verbose logs                                                                                              | int          |
+| voice_externalDisallowJoin | 0       | Disables players being allowed to join the server, should only be used if you're using a FXServer as a external mumble server.    | int          |
+| voice_hideEndpoints        | 1       | Hides the mumble address in logs _NOTE: You should only care to hide this for a external server._                                 | int          |
 
 ### Aces
 
@@ -108,96 +108,94 @@ This would only allow the superadmin group to mute players.
 
 ##### Setters
 
-| Export              | Description                 | Parameter(s) |
-|---------------------|-----------------------------|--------------|
-| [setVoiceProperty](docs/client-setters/setVoiceProperty.md)    | Set config options          | string, any  |
-| [setRadioChannel](docs/client-setters/setRadioChannel.md)     | Set radio channel           | int          |
-| [setCallChannel](docs/client-setters/setCallChannel.md)      | Set call channel            | int          |
-| [setRadioVolume](docs/client-setters/setRadioVolume.md)      | Set radio volume for player | int          |
-| [setCallVolume](docs/client-setters/setCallVolume.md)        | Set call volume for player  | int          |
-| [setMicClickOnVolume](docs/client-setters/setMicClickOnVolume.md)      | Set mic click on volume for player | int          |
-| [setMicClickOffVolume](docs/client-setters/setCallVolume.md)        | Set mic click off volume for player  | int          |
-| [addPlayerToRadio](docs/client-setters/setRadioChannel.md)      | Set radio channel        | int          |
-| [addPlayerToCall](docs/client-setters/setCallChannel.md)       | Set call channel         | int          |
-| [removePlayerFromRadio](docs/client-setters/removePlayerFromRadio.md) | Remove player from radio |              |
-| [removePlayerFromCall](docs/client-setters/removePlayerFromCall.md)  | Remove player from call  |              |
+| Export                                                                | Description                         | Parameter(s) |
+| --------------------------------------------------------------------- | ----------------------------------- | ------------ |
+| [setVoiceProperty](docs/client-setters/setVoiceProperty.md)           | Set config options                  | string, any  |
+| [setRadioChannel](docs/client-setters/setRadioChannel.md)             | Set radio channel                   | int          |
+| [setCallChannel](docs/client-setters/setCallChannel.md)               | Set call channel                    | int          |
+| [setRadioVolume](docs/client-setters/setRadioVolume.md)               | Set radio volume for player         | int          |
+| [setCallVolume](docs/client-setters/setCallVolume.md)                 | Set call volume for player          | int          |
+| [setMicClickOnVolume](docs/client-setters/setMicClickOnVolume.md)     | Set mic click on volume for player  | int          |
+| [setMicClickOffVolume](docs/client-setters/setCallVolume.md)          | Set mic click off volume for player | int          |
+| [addPlayerToRadio](docs/client-setters/setRadioChannel.md)            | Set radio channel                   | int          |
+| [addPlayerToCall](docs/client-setters/setCallChannel.md)              | Set call channel                    | int          |
+| [removePlayerFromRadio](docs/client-setters/removePlayerFromRadio.md) | Remove player from radio            |              |
+| [removePlayerFromCall](docs/client-setters/removePlayerFromCall.md)   | Remove player from call             |              |
 
 ##### Toggles
 
-| Export              | Description                                            | Parameter(s) |
-|---------------------|--------------------------------------------------------|--------------|
-| toggleMutePlayer    | Toggles the selected player muted for the local client | int          |
+| Export           | Description                                            | Parameter(s) |
+| ---------------- | ------------------------------------------------------ | ------------ |
+| toggleMutePlayer | Toggles the selected player muted for the local client | int          |
 
 Supported from mumble-voip / toko-voip
 
-| Export                | Description              | Parameter(s) |
-|-----------------------|--------------------------|--------------|
-| [SetMumbleProperty](docs/client-setters/setVoiceProperty.md)     | Set config options       | string, any  |
-| [SetTokoProperty](docs/client-setters/setVoiceProperty.md)       | Set config options       | string, any  |
-| [SetRadioChannel](docs/client-setters/setRadioChannel.md)       | Set radio channel        | int          |
-| [SetCallChannel](docs/client-setters/setCallChannel.md)        | Set call channel         | int          |
+| Export                                                       | Description        | Parameter(s) |
+| ------------------------------------------------------------ | ------------------ | ------------ |
+| [SetMumbleProperty](docs/client-setters/setVoiceProperty.md) | Set config options | string, any  |
+| [SetTokoProperty](docs/client-setters/setVoiceProperty.md)   | Set config options | string, any  |
+| [SetRadioChannel](docs/client-setters/setRadioChannel.md)    | Set radio channel  | int          |
+| [SetCallChannel](docs/client-setters/setCallChannel.md)      | Set call channel   | int          |
 
 #### Getters
 
 The majority of setters are done through player states.
 
-
-| State Bag     | Description                                                  | Return Type  |
-|---------------|--------------------------------------------------------------|--------------|
-| [proximity](docs/state-getters/stateBagGetters.md)     | Returns a table with the mode index, distance, and mode name | table        |
-| [radioChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current radio channel, or 0 for none     | int          |
-| [callChannel](docs/state-getters/stateBagGetters.md)   | Returns the players current call channel, or 0 for none      | int          |
-| [disableRadio](docs/state-getters/stateBagGetters.md)   | Returns if the players radio is currently disabled, or 0 if its not. This is expected to be use as a bitwise, do *not* use a bool | int          |
+| State Bag                                             | Description                                                                                                                       | Return Type |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [proximity](docs/state-getters/stateBagGetters.md)    | Returns a table with the mode index, distance, and mode name                                                                      | table       |
+| [radioChannel](docs/state-getters/stateBagGetters.md) | Returns the players current radio channel, or 0 for none                                                                          | int         |
+| [callChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current call channel, or 0 for none                                                                           | int         |
+| [disableRadio](docs/state-getters/stateBagGetters.md) | Returns if the players radio is currently disabled, or 0 if its not. This is expected to be use as a bitwise, do _not_ use a bool | int         |
 
 #### Events
 
 These are events designed for third-party resource integration. These are emitted only to the current client.
 
-| Event                    | Description                                                  | Event Params   |
-|--------------------------|--------------------------------------------------------------|----------------|
+| Event                                                       | Description                                                | Event Params      |
+| ----------------------------------------------------------- | ---------------------------------------------------------- | ----------------- |
 | [pma-voice:settingsCallback](docs/client-getters/events.md) | When emited it will return the current pma-voice settings. | cb(voiceSettings) |
-| [pma-voice:radioActive](docs/client-getters/events.md) | Triggered when the radio is activated / deactivated | boolean |
-| [pma-voice:setTalkingMode](docs/client-getters/events.md) | Triggered on proximity mode change with the voice mode id | int |
-
+| [pma-voice:radioActive](docs/client-getters/events.md)      | Triggered when the radio is activated / deactivated        | boolean           |
+| [pma-voice:setTalkingMode](docs/client-getters/events.md)   | Triggered on proximity mode change with the voice mode id  | int               |
 
 #### Server
 
 ##### Setters
 
-| Export               | Description                          | Parameter(s) |
-|----------------------|--------------------------------------|--------------|
-| [setPlayerRadio](docs/server-setters/setPlayerRadio.md)       | Sets the players radio channel       | int, int     |
-| [setPlayerCall](docs/server-setters/setPlayerCall.md)        | Sets the players call channel        | int, int     |
-| [addChannelCheck](docs/server-setters/addChannelCheck.md)      | Adds a channel check to the players radio channel | int, function |
-
+| Export                                                    | Description                                       | Parameter(s)  |
+| --------------------------------------------------------- | ------------------------------------------------- | ------------- |
+| [setPlayerRadio](docs/server-setters/setPlayerRadio.md)   | Sets the players radio channel                    | int, int      |
+| [setPlayerCall](docs/server-setters/setPlayerCall.md)     | Sets the players call channel                     | int, int      |
+| [addChannelCheck](docs/server-setters/addChannelCheck.md) | Adds a channel check to the players radio channel | int, function |
 
 ##### Getters
 
 ###### State Bags
+
 You can access the state with `Player(source).state['state bag here']`
 
-| State Bag     | Description                                                  | Return Type  |
-|---------------|--------------------------------------------------------------|--------------|
-| [proximity](docs/state-getters/stateBagGetters.md)     | Returns a table with the mode index, distance, and mode name | table        |
-| [radioChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current radio channel, or 0 for none     | int          |
-| [callChannel](docs/state-getters/stateBagGetters.md)   | Returns the players current call channel, or 0 for none      | int          |
-| [voiceIntent](docs/state-getters/stateBagGetters.md) | Returns the players current voice intent, either 'speech' or 'music' | string |
-| [disableRadio](docs/state-getters/stateBagGetters.md)   | Returns if the players radio is currently disabled, or 0 if its not. This is expected to be use as a bitwise, do *not* use a bool | int          |
+| State Bag                                             | Description                                                                                                                       | Return Type |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [proximity](docs/state-getters/stateBagGetters.md)    | Returns a table with the mode index, distance, and mode name                                                                      | table       |
+| [radioChannel](docs/state-getters/stateBagGetters.md) | Returns the players current radio channel, or 0 for none                                                                          | int         |
+| [callChannel](docs/state-getters/stateBagGetters.md)  | Returns the players current call channel, or 0 for none                                                                           | int         |
+| [voiceIntent](docs/state-getters/stateBagGetters.md)  | Returns the players current voice intent, either 'speech' or 'music'                                                              | string      |
+| [disableRadio](docs/state-getters/stateBagGetters.md) | Returns if the players radio is currently disabled, or 0 if its not. This is expected to be use as a bitwise, do _not_ use a bool | int         |
 
 ```ts
 enum DisabledRadioStates {
-	Enabled = 0,
-	IsDead = 1,
-	IsCuffed = 2,
-	IsPdCuffed = 4,
-	IsUnderWater = 8,
-	DoesntHaveItem = 16,
-	PlayerDisabledRadio = 32,
+  Enabled = 0,
+  IsDead = 1,
+  IsCuffed = 2,
+  IsPdCuffed = 4,
+  IsUnderWater = 8,
+  DoesntHaveItem = 16,
+  PlayerDisabledRadio = 32,
 }
 ```
 
 ###### Exports
 
-| Export                       | Description                                       | Parameter(s) |
-|------------------------------|---------------------------------------------------|------|
-| [getPlayersInRadioChannel](docs/server-getters/getPlayersInRadioChannel.md)     | Gets the current players in a radio channel       | int  |
+| Export                                                                      | Description                                 | Parameter(s) |
+| --------------------------------------------------------------------------- | ------------------------------------------- | ------------ |
+| [getPlayersInRadioChannel](docs/server-getters/getPlayersInRadioChannel.md) | Gets the current players in a radio channel | int          |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ All of the configs here are set using `setr [voice_configOption] [int]` OR `setr
 | voice_enableRadios           |    1    | Enables the radio sub-modules                                 | int          |
 | voice_enableCalls           |    1    | Enables the call sub-modules                                 | int          |
 | voice_enableSubmix      |    1    | Enables the submix which adds a radio/call style submix to their voice **NOTE: Submixs require native audio** | int          |
+| voice_disableRadioSubmix      |    0    | Disables only the radio submix, 1 = true = disabled. `voice_enableSubmix` has priority over this. | int          |
+| voice_disableCallSubmix      |    0    | Disables only the call submix, 1 = true = disabled. `voice_enableSubmix` has priority over this. | int          |
 | voice_enableRadioAnim        |   1     | Enables (grab shoulder mic) animation while talking on the radio.          | int          |
 | voice_defaultRadio           |   LMENU  | The default key to use the radio. You can find a list of valid keys [in the FiveM docs](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/)                             | string       |
 

--- a/client/init/main.lua
+++ b/client/init/main.lua
@@ -148,11 +148,19 @@ local disableSubmixReset = {}
 function toggleVoice(plySource, enabled, moduleType)
 	if mutedPlayers[plySource] then return end
 	logger.verbose('[main] Updating %s to talking: %s with submix %s', plySource, enabled, moduleType)
+	local submixEnabled =
+		-- If this is explicitly disabled, then it shouldnt matter if voice_disableRadioSubmix or voice_disableCallSubmix is enabled
+		GetConvarInt('voice_enableSubmix', 1) == 1 and
+		-- Allow external resources to take full ownership of radio submix or call submix
+		(
+			(moduleType == 'radio' and GetConvarInt('voice_disableRadioSubmix', 0) == 1)
+			or (moduleType == 'call' and GetConvarInt('voice_disableCallSubmix', 0) == 1)
+		)
+
 	local distance = currentTargets[plySource]
 	if enabled and (not distance or distance > 4.0) then
-		print(volumes[moduleType])
 		MumbleSetVolumeOverrideByServerId(plySource, enabled and volumes[moduleType])
-		if GetConvarInt('voice_enableSubmix', 1) == 1 then
+		if submixEnabled then
 			if moduleType then
 				disableSubmixReset[plySource] = true
 				if submixIndicies[moduleType] then
@@ -163,7 +171,7 @@ function toggleVoice(plySource, enabled, moduleType)
 			end
 		end
 	elseif not enabled then
-		if GetConvarInt('voice_enableSubmix', 1) == 1 then
+		if submixEnabled then
 			-- garbage collect it
 			disableSubmixReset[plySource] = nil
 			SetTimeout(250, function()
@@ -312,9 +320,9 @@ if gameVersion == 'redm' then
 	local KEY_LEFT_ALT = 0xA4
 
 	RegisterRawKeymap("pma-voice_radioTalk", function()
-			ExecuteCommand('+radiotalk')
+		ExecuteCommand('+radiotalk')
 	end, function()
-			ExecuteCommand('-radiotalk')
+		ExecuteCommand('-radiotalk')
 	end, KEY_LEFT_ALT, true)
 end
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -55,6 +55,8 @@ convar_category 'PMA-Voice' {
 		{ "Proximity cycle key",                   "$voice_defaultCycle",         "CV_STRING", "F11" },
 		{ "Voice radio volume",                    "$voice_defaultRadioVolume",   "CV_INT",    "30" },
 		{ "Voice call volume",                     "$voice_defaultCallVolume",    "CV_INT",    "60" },
+		{ "Volume of radio on mic click",          "$voice_onClickVolume",        "CV_INT",    "10" },
+		{ "Volume of radio off mic click",         "$voice_offClickVolume",       "CV_INT",    "3" },
 		{ "Enable radios",                         "$voice_enableRadios",         "CV_INT",    "1" },
 		{ "Enable calls",                          "$voice_enableCalls",          "CV_INT",    "1" },
 		{ "Enable submix",                         "$voice_enableSubmix",         "CV_INT",    "1" },

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -58,6 +58,8 @@ convar_category 'PMA-Voice' {
 		{ "Enable radios",                         "$voice_enableRadios",         "CV_INT",    "1" },
 		{ "Enable calls",                          "$voice_enableCalls",          "CV_INT",    "1" },
 		{ "Enable submix",                         "$voice_enableSubmix",         "CV_INT",    "1" },
+		{ "Disable radio submix",                  "$voice_disableRadioSubmix",   "CV_INT",    "0" },
+		{ "Disable call submix",                   "$voice_disableCallSubmix",    "CV_INT",    "0" },
 		{ "Enable radio animation",                "$voice_enableRadioAnim",      "CV_INT",    "0" },
 		{ "Radio key",                             "$voice_defaultRadio",         "CV_STRING", "LMENU" },
 		{ "UI refresh rate",                       "$voice_uiRefreshRate",        "CV_INT",    "200" },


### PR DESCRIPTION
This PR aims to:
- Add convars for specifically disabling the radio and or call submix. Example usage: you want to disable the radio submix, while not touching the call submix, which isnt currently possible due to the "global" voice_enableSubmix convar instead.
- Document these changes (ofcourse)
- Linted/formatted the README file (I just saved and it auto formatted lol, kinda nice QOL, up to y'all if you want to keep it or not, just let me know)
- I also documented the `voice_onClickVolume` & `voice_offClickVolume` convars which I previously had a PR for in the fxmanifest, which I seem to have missed in that previous PR.
- Also removed some weird debug log on line 153 of `client/init/main.lua`, as its spamming the user's f8 console every time someone talks over the radio. Which I ASSUME isnt intended.

I have partially tested this ingame, with the disabling the radio submix, not tested anything concerning the call submix. But in theory it should work and is the same logic.

Thank you