### PR TITLE
feat: export for removing a channel check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ These are events designed for third-party resource integration. These are emitte
 | [setPlayerRadio](docs/server-setters/setPlayerRadio.md)       | Sets the players radio channel       | int, int     |
 | [setPlayerCall](docs/server-setters/setPlayerCall.md)        | Sets the players call channel        | int, int     |
 | [addChannelCheck](docs/server-setters/addChannelCheck.md)      | Adds a channel check to the players radio channel | int, function |
-
+| [removeChannelCheck](docs/server-setters/removeChannelCheck.md)      | Removes a channel check for the players radio channel | int |
 
 ##### Getters
 

--- a/docs/server-setters/removeChannelCheck.md
+++ b/docs/server-setters/removeChannelCheck.md
@@ -1,0 +1,15 @@
+## removeChannelCheck
+
+## Description
+
+Removes a channel check for radio channel.
+
+## Parameters
+
+* **channel**: The channel to remove the check from.
+
+```lua
+-- Example for Removes
+-- this always has to return true/false
+exports['pma-voice']:removeChannelCheck(1)
+```

--- a/docs/server-setters/removeChannelCheck.md
+++ b/docs/server-setters/removeChannelCheck.md
@@ -10,6 +10,5 @@ Removes a channel check for radio channel.
 
 ```lua
 -- Example for Removes
--- this always has to return true/false
 exports['pma-voice']:removeChannelCheck(1)
 ```

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -28,9 +28,24 @@ function addChannelCheck(channel, cb)
 	end
 	radioChecks[channel] = cb
 	logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
+	return true
 end
 
 exports('addChannelCheck', addChannelCheck)
+
+--- removes any check for the channel, function is expected to return a boolean of true or false
+---@param channel number the channel to add a check to
+function removeChannelCheck(channel)
+	local channelType = type(channel)
+	if channelType ~= "number" then
+		error(("'channel' expected 'number' got '%s'"):format(channelType))
+	end
+	radioChecks[channel] = nil
+	logger.info("%s removed check for channel %s", GetInvokingResource(), channel)
+	return true
+end
+
+exports("removeChannelCheck", removeChannelCheck)
 
 local function radioNameGetter_orig(source)
 	return GetPlayerName(source)

--- a/server/module/radio.lua
+++ b/server/module/radio.lua
@@ -28,12 +28,11 @@ function addChannelCheck(channel, cb)
 	end
 	radioChecks[channel] = cb
 	logger.info("%s added a check to channel %s", GetInvokingResource(), channel)
-	return true
 end
 
 exports('addChannelCheck', addChannelCheck)
 
---- removes any check for the channel, function is expected to return a boolean of true or false
+--- removes any check for the channel
 ---@param channel number the channel to add a check to
 function removeChannelCheck(channel)
 	local channelType = type(channel)
@@ -42,7 +41,6 @@ function removeChannelCheck(channel)
 	end
 	radioChecks[channel] = nil
 	logger.info("%s removed check for channel %s", GetInvokingResource(), channel)
-	return true
 end
 
 exports("removeChannelCheck", removeChannelCheck)


### PR DESCRIPTION
There's currently no export for removing a channel join check / guard - only for adding one.
You can in theory run the add function with an empty function, but that isnt really that ideal imo, nor intuitive.